### PR TITLE
Add initial implementation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["latest"]
+}

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,6 @@
+extends: seegno
+
+rules:
+  id-match: 0
+  no-process-env: 0
+  no-return-assign: 0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # github-changelog-generator
 Generate changelog files from the project's Github PRs
+
+## Usage
+Generate a new [Github Personal Access Token](https://github.com/settings/tokens) and save it it your `.zshrc.local`, `.bashrc.local` or similar:
+
+```sh
+export GITHUB_TOKEN=<your_github_personal_access_token>
+```
+
+To generate a changelog for your Github project, use the following command:
+
+```sh
+$ OWNER=<repo_owner> REPO=<repo_name> FUTURE_RELEASE=<release_name> github-changelog-generator > <your_changelog_file>
+```
+
+Example:
+
+```sh
+$ OWNER=uphold REPO=github-changelog-generator FUTURE_RELEASE=1.2.3 github-changelog-generator > CHANGELOG.md
+```
+
+The `FUTURE_RELEASE` option is optional. If you just want to build a new changelog without a new release, you can skip that option, and `github-changelog-generator` will create a changelog for existing releases only.

--- a/bin/github-changelog-generator.js
+++ b/bin/github-changelog-generator.js
@@ -1,0 +1,2 @@
+#! /usr/bin/env node
+require('../dist/index');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "github-changelog-generator",
+  "version": "0.0.0",
+  "description": "Generate changelog files from the project's Github PRs",
+  "main": "dist/index.js",
+  "scripts": {
+    "lint": "eslint src",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "transpile": "rm -rf dist/* && babel src --copy-files --out-dir dist"
+  },
+  "author": "Ricardo Lopes",
+  "license": "MIT",
+  "bin": {
+    "github-changelog-generator": "bin/github-changelog-generator.js"
+  },
+  "dependencies": {
+    "bluebird": "^3.4.6",
+    "github": "^6.1.0",
+    "lodash": "^4.17.2",
+    "moment": "^2.17.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.18.0",
+    "babel-core": "^6.18.2",
+    "babel-polyfill": "^6.16.0",
+    "babel-preset-latest": "^6.16.0",
+    "eslint": "^3.10.2",
+    "eslint-config-seegno": "^8.0.1"
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,136 @@
+
+/**
+ * Module dependencies.
+ */
+
+const { assign, chain, concat, flatten, find, range } = require('lodash');
+const GitHubApi = require('github');
+const Promise = require('bluebird');
+const moment = require('moment');
+
+/**
+ * Options.
+ */
+
+const concurrency = 20;
+const futureRelease = process.env.FUTURE_RELEASE;
+const token = process.env.GITHUB_TOKEN;
+const owner = process.env.OWNER;
+const repo = process.env.REPO;
+
+/**
+ * Set up Github API connection.
+ */
+
+const github = new GitHubApi({ Promise });
+
+github.authenticate({ token, type: 'token' });
+
+/**
+ * Assign a PR to a release.
+ */
+
+function assignPrToRelease(releases, pr) {
+  const release = find(releases, release => pr.merged_at.isSameOrBefore(release.created_at));
+
+  if (release) {
+    release.prs.unshift(pr);
+  }
+}
+
+/**
+ * Get results from the next pages.
+ */
+
+async function getResultsFromNextPages(results, fn) {
+  const lastPage = results.meta.link.match(/<[^>]+[&?]page=([0-9]+)[^>]+>; rel="last"/)[1];
+  const pages = range(2, lastPage + 1);
+
+  return concat(results, flatten(await Promise.map(pages, fn, { concurrency })));
+}
+
+/**
+ * Get a page of releases.
+ */
+
+async function getReleasesPage(page = 1) {
+  return await github.repos.getReleases({ owner, page, per_page: 100, repo });
+}
+
+/**
+ * Get all releases.
+ */
+
+async function getAllReleases() {
+  const releases = await getReleasesPage();
+
+  if (futureRelease) {
+    releases.unshift({
+      created_at: moment().format(),
+      html_url: `https://github.com/uphold/backend/releases/tag/${futureRelease}`,
+      name: futureRelease
+    });
+  }
+
+  return chain(await getResultsFromNextPages(releases, getReleasesPage))
+    .map(release => assign(release, { created_at: moment.utc(release.created_at), prs: [] }))
+    .sortBy(release => release.created_at.unix())
+    .value();
+}
+
+/**
+ * Get a page of PRs.
+ */
+
+async function getPullRequestsPage(page = 1) {
+  return await github.pullRequests.getAll({ owner, page, per_page: 100, repo, state: 'closed' });
+}
+
+/**
+ * Get all PRs.
+ */
+
+async function getAllPullRequests() {
+  const prs = await getPullRequestsPage();
+
+  return chain(await getResultsFromNextPages(prs, getPullRequestsPage))
+    .map(pr => assign(pr, { merged_at: moment.utc(pr.merged_at) }))
+    .sortBy(pr => pr.merged_at.unix())
+    .value();
+}
+
+/**
+ * Generate and write the  formatted changelog.
+ */
+
+function writeChangelog(releases) {
+  const changelog = ['# Changelog\n'];
+
+  for (const release of releases) {
+    changelog.push(`\n## [${release.name}](${release.html_url}) (${release.created_at.format('YYYY-MM-DD')})\n`);
+
+    for (const pr of release.prs) {
+      changelog.push(`- ${pr.title} [${pr.number}](${pr.html_url}) ([${pr.user.login}](${pr.user.html_url}))\n`);
+    }
+  }
+
+  changelog.forEach(line => process.stdout.write(line));
+}
+
+/**
+ * Run the changelog generator.
+ */
+
+async function run() {
+  const [releases, prs] = await Promise.all([getAllReleases(), getAllPullRequests()]);
+
+  prs.forEach(pr => assignPrToRelease(releases, pr));
+
+  writeChangelog(releases.reverse());
+}
+
+/**
+ * Run.
+ */
+
+run();

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,2 @@
+require('babel-polyfill');
+require('./app');


### PR DESCRIPTION
Add first version of the project.

In this PR we're getting a full changelog generator that is outputted to stdout (so that it can be used with UNIX pipes).

There are still improvements to do, like adding unit tests, better handling edge cases (e.g. dealing with projects with no releases or PRs yet), and maybe switching from releases to tags. Those should be added in future PRs.