### PR TITLE
Fix future release URL

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -72,7 +72,7 @@ async function getAllReleases() {
   if (futureRelease) {
     releases.unshift({
       created_at: moment().format(),
-      html_url: `https://github.com/uphold/backend/releases/tag/${futureRelease}`,
+      html_url: `https://github.com/uphold/backend/releases/tag/v${futureRelease}`,
       name: futureRelease
     });
   }


### PR DESCRIPTION
To comply with how `npm version` generates tags (prepends `v` to the version number).