### PR TITLE
Allow specifying release tag names

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,25 @@ $ github-changelog-generator --help
 
   Options:
 
-    -h, --help                      output usage information
-    -o, --owner <name>              [required] owner of the repository
-    -r, --repo <name>               [required] name of the repository
-    -f, --future-release <version>  [optional] specify the next release tag
+    -h, --help                       output usage information
+    -o, --owner <name>               [required] owner of the repository
+    -r, --repo <name>                [required] name of the repository
+    -f, --future-release <version>   [optional] specify the next release version
+    -t, --future-release-tag <name>  [optional] specify the next release tag name if it is different from the release version
 ```
 
 To generate a changelog for your Github project, use the following command:
 
 ```sh
-$ github-changelog-generator --owner=<repo_owner> --repo=<repo_name> --future-release=<release_name>  > <your_changelog_file>
+$ github-changelog-generator --owner=<repo_owner> --repo=<repo_name> --future-release=<release_name> --future-release-tag=<release_tag_name>  > <your_changelog_file>
 ```
 
-The `--future-release` option is optional. If you just want to build a new changelog without a new release, you can skip that option, and `github-changelog-generator` will create a changelog for existing releases only.
+The `--future-release` and `--future-release-tag` options are optional. If you just want to build a new changelog without a new release, you can skip those options, and `github-changelog-generator` will create a changelog for existing releases only. Also, if your future release tag name is the same as your future release version number, then you can skip `--future-release-tag`.
 
 Example:
 
 ```sh
-$ github-changelog-generator --owner=uphold --repo=github-changelog-generator --future-release=1.2.3 > CHANGELOG.md
+$ github-changelog-generator --owner=uphold --repo=github-changelog-generator --future-release=1.2.3 --future-release-tag=v1.2.3 > CHANGELOG.md
 ```
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,8 @@ const program = require('commander');
 program
   .option('-o, --owner <name>', '[required] owner of the repository')
   .option('-r, --repo <name>', '[required] name of the repository')
-  .option('-f, --future-release <version>', '[optional] specify the next release tag')
+  .option('-f, --future-release <version>', '[optional] specify the next release version')
+  .option('-t, --future-release-tag <name>', '[optional] specify the next release tag name if it is different from the release version')
   .description('Run Github changelog generator.')
   .parse(process.argv);
 
@@ -26,6 +27,7 @@ program
 
 const concurrency = 20;
 const { futureRelease, owner, repo } = program;
+const futureReleaseTag = program.futureReleaseTag || futureRelease;
 const token = process.env.GITHUB_TOKEN;
 
 if (!owner || !repo) {
@@ -88,7 +90,7 @@ async function getAllReleases() {
   if (futureRelease) {
     releases.unshift({
       created_at: moment().format(),
-      html_url: `https://github.com/${owner}/${repo}/releases/tag/${futureRelease}`,
+      html_url: `https://github.com/${owner}/${repo}/releases/tag/${futureReleaseTag}`,
       name: futureRelease
     });
   }


### PR DESCRIPTION
This changelog generator was assuming the future release tag name would be the same as its version number (e.g. version 1.2.3 would have the `1.2.3` tag).

However, that assumption is not always correct. For instance, when we run `npm version`, we actually get a tag that prefixes 'v' (e.g. version 1.2.3 would have the `v1.2.3` tag).

In those situations, we have to either delete that tag and create a new one that matches the version number, or manually edit the generated changelog to fix the generated URL for the new release.

There are two possible approaches to fix this problem:
1. have this package control how version tags are generated so that it can know how to generate the right URL for it every time
2. accept an additional optional argument to specify the release tag name when it's different than the version number

The problem with the first approach is that it limits any projects that use this tool. All projects that wouldn't comply with this tool's selected approach would have to either change or be unable to use this tool. That sounds like a bad compromise.

Therefore this PR explores the second approach. This lets projects that use this tool specify the future release tag name to avoid any manual corrections afterwards.