### PR TITLE
Fix empty release names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,7 @@ function writeChangelog(releases) {
   const changelog = ['# Changelog\n'];
 
   for (const release of releases) {
-    changelog.push(`\n## [${release.name}](${release.html_url}) (${release.created_at.format('YYYY-MM-DD')})\n`);
+    changelog.push(`\n## [${release.name || release.tag_name}](${release.html_url}) (${release.created_at.format('YYYY-MM-DD')})\n`);
 
     for (const pr of release.prs) {
       changelog.push(`- ${pr.title} [\\#${pr.number}](${pr.html_url}) ([${pr.user.login}](${pr.user.html_url}))\n`);


### PR DESCRIPTION
Resolves https://github.com/uphold/github-changelog-generator/issues/32.

Uses the value of a release's `tag_name` when its `name` is not set, to avoid empty release names creeping into the generated changelog.