### PR TITLE
Generation of CHANGELOG filtering merges by base branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ github-changelog-generator --help
     -h, --help                       output usage information
     -o, --owner <name>               [required] owner of the repository
     -r, --repo <name>                [required] name of the repository
+    -b, --base-branch <name>         [optional] specify the base branch name - master by default
     -f, --future-release <version>   [optional] specify the next release version
     -t, --future-release-tag <name>  [optional] specify the next release tag name if it is different from the release version
 ```
@@ -29,7 +30,15 @@ $ github-changelog-generator --help
 To generate a changelog for your Github project, use the following command:
 
 ```sh
-$ github-changelog-generator --owner=<repo_owner> --repo=<repo_name> --future-release=<release_name> --future-release-tag=<release_tag_name>  > <your_changelog_file>
+$ github-changelog-generator --owner=<repo_owner> --repo=<repo_name> --base-branch=<base> --future-release=<release_name> --future-release-tag=<release_tag_name> > <your_changelog_file>
+```
+
+The `--base-branch` option is optional. It allows you to filter the PRs by base branch and uses master by default.
+
+Example:
+
+```sh
+$ github-changelog-generator --owner=uphold --repo=github-changelog-generator --base-branch=production > CHANGELOG.md
 ```
 
 The `--future-release` and `--future-release-tag` options are optional. If you just want to build a new changelog without a new release, you can skip those options, and `github-changelog-generator` will create a changelog for existing releases only. Also, if your future release tag name is the same as your future release version number, then you can skip `--future-release-tag`.

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ const program = require('commander');
 program
   .option('-o, --owner <name>', '[required] owner of the repository')
   .option('-r, --repo <name>', '[required] name of the repository')
+  .option('-b, --base-branch <name>', '[optional] specify the base branch name - master by default')
   .option('-f, --future-release <version>', '[optional] specify the next release version')
   .option('-t, --future-release-tag <name>', '[optional] specify the next release tag name if it is different from the release version')
   .description('Run Github changelog generator.')
@@ -25,6 +26,7 @@ program
  * Options.
  */
 
+const base = program.baseBranch || 'master';
 const concurrency = 20;
 const { futureRelease, owner, repo } = program;
 const futureReleaseTag = program.futureReleaseTag || futureRelease;
@@ -106,7 +108,7 @@ async function getAllReleases() {
  */
 
 async function getPullRequestsPage(page = 1) {
-  return await github.pullRequests.getAll({ owner, page, per_page: 100, repo, state: 'closed' });
+  return await github.pullRequests.getAll({ base, owner, page, per_page: 100, repo, state: 'closed' });
 }
 
 /**


### PR DESCRIPTION
Closes #42.

New optional parameter to set base branch value - using 'master' as default.
Updated getPullRequestsPage function to use parameter value in pullRequests.getAll call.