### PR TITLE
Owner and repo default values from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,20 @@ $ github-changelog-generator --help
   Options:
 
     -h, --help                       output usage information
-    -o, --owner <name>               [required] owner of the repository
-    -r, --repo <name>                [required] name of the repository
     -f, --future-release <version>   [optional] specify the next release version
     -t, --future-release-tag <name>  [optional] specify the next release tag name if it is different from the release version
+    -o, --owner <name>               [optional] specify owner of the repository. If no value is provided, repository field data in package.json will be used
+    -r, --repo <name>                [optional] specify name of the repository. If no value is provided, repository field data in package.json will be used
 ```
 
 To generate a changelog for your Github project, use the following command:
 
 ```sh
-$ github-changelog-generator --owner=<repo_owner> --repo=<repo_name> --future-release=<release_name> --future-release-tag=<release_tag_name>  > <your_changelog_file>
+$ github-changelog-generator --future-release=<release_name> --future-release-tag=<release_tag_name> --owner=<repo_owner> --repo=<repo_name> > <your_changelog_file>
 ```
 
+If no `--owner` or `--repo` options are provided, `package.json` will be used to parse the missing information.
+ 
 The `--future-release` and `--future-release-tag` options are optional. If you just want to build a new changelog without a new release, you can skip those options, and `github-changelog-generator` will create a changelog for existing releases only. Also, if your future release tag name is the same as your future release version number, then you can skip `--future-release-tag`.
 
 Example:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "commander": "^2.9.0",
     "github": "^6.1.0",
     "lodash": "^4.17.2",
-    "moment": "^2.17.0"
+    "moment": "^2.17.0",
+    "parse-github-url": "^1.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1459,6 +1459,10 @@ output-file-sync@^1.1.0:
     mkdirp "^0.5.1"
     object-assign "^4.1.0"
 
+parse-github-url@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parse-github-url/-/parse-github-url-1.0.2.tgz#242d3b65cbcdda14bb50439e3242acf6971db395"
+
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"


### PR DESCRIPTION
Closes #14.

Added usage of package.json `repository` field data to find owner and repo default values. Using [parse-github-url](https://www.npmjs.com/package/parse-github-url).