### PR TITLE
Prefill changelog from existing file

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,3 +5,4 @@ rules:
   no-process-env: 0
   no-process-exit: 0
   no-return-assign: 0
+  no-sync: 0

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ $ github-changelog-generator --help
     -r, --repo <name>                [required] name of the repository
     -b, --base-branch <name>         [optional] specify the base branch name - master by default
     -f, --future-release <version>   [optional] specify the next release version
+    -p, --prefill-from <filename>    [optional] specify the existing changelog file to prefill changelog data from
     -t, --future-release-tag <name>  [optional] specify the next release tag name if it is different from the release version
 ```
 
@@ -47,6 +48,14 @@ Example:
 
 ```sh
 $ github-changelog-generator --owner=uphold --repo=github-changelog-generator --future-release=1.2.3 --future-release-tag=v1.2.3 > CHANGELOG.md
+```
+
+For large projects that might hit GitHub's ratelimits when generating the full changelog, the optional `--prefill-from` accepts an existing changelog file to prefill the existing information from there and require only the latest changes.
+
+Example:
+
+```sh
+$ github-changelog-generator --owner=uphold --repo=github-changelog-generator --prefill-from=CHANGELOG.md > CHANGELOG.md
 ```
 
 


### PR DESCRIPTION
Resolves https://github.com/uphold/github-changelog-generator/issues/45. No breaking change required (uses a new CLI option).