### PR TITLE
Fix excessive API calls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ async function getResultsFromNextPages(results, fn) {
   let lastPage = 1;
 
   if (has(results, 'meta.link')) {
-    lastPage = results.meta.link.match(/<[^>]+[&?]page=([0-9]+)[^>]+>; rel="last"/)[1];
+    lastPage = Number(results.meta.link.match(/<[^>]+[&?]page=([0-9]+)[^>]+>; rel="last"/)[1]);
   }
 
   const pages = range(2, lastPage + 1);


### PR DESCRIPTION
Getting `lastPage` from the API response's navigation details gets us a string, not a number. This means that when we were calculating the pages to fetch with `range(2, lastPage + 1)`, we were actually doing a sum operation on a string, which would append `1` to the end of it. So, for a project with e.g. 50 pages of PRs, instead of querying from page 2 to page 50, we were querying from page 2 to page 500, resulting in 10x the API load.

This PR fixes that bug by casting `lastPage` to number. With this fix, large projects will see a noticeable performance improvement generating changelogs, and will have a lot more free room before rate limits may apply.