### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ language: node_js
 cache: yarn
 
 node_js:
-  - 6
   - 8
   - 10
-  - 11
+  - 12
 
 script:
   - yarn lint

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
     "babel-plugin-transform-async-to-module-method": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-node6": "^11.0.0",
-    "eslint": "^5.8.0",
-    "eslint-config-uphold": "^0.2.0",
+    "eslint": "^6.5.1",
+    "eslint-config-uphold": "^1.0.0",
     "jest": "^23.6.0",
     "nock": "^10.0.1",
-    "pre-commit": "^1.2.2"
+    "pre-commit": "^1.2.2",
+    "prettier": "^1.18.2"
   },
   "engines": {
     "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prettier": "^1.18.2"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "jest": {
     "collectCoverage": true,

--- a/src/changelog-fetcher.js
+++ b/src/changelog-fetcher.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -73,11 +72,23 @@ class ChangelogFetcher {
       state: 'closed'
     };
     const prs = await this.client.pullRequests.list(options);
-    const nextPages = await Promise.map(this.getNextPages(prs), page => this.client.pullRequests.list({ ...options, page }), { concurrency });
+    const nextPages = await Promise.map(
+      this.getNextPages(prs),
+      page => this.client.pullRequests.list({ ...options, page }),
+      { concurrency }
+    );
 
     return chain(prs.data)
       .concat(flatMap(nextPages, 'data'))
-      .filter(({ labels }) => isEmpty(this.labels) || !chain(labels).map('name').intersection(this.labels).isEmpty().value())
+      .filter(
+        ({ labels }) =>
+          isEmpty(this.labels) ||
+          !chain(labels)
+            .map('name')
+            .intersection(this.labels)
+            .isEmpty()
+            .value()
+      )
       .map(pr => assign(pr, { merged_at: moment.utc(pr.merged_at) }))
       .sortBy(pr => pr.merged_at.unix())
       .value();
@@ -105,7 +116,11 @@ class ChangelogFetcher {
       });
     }
 
-    const nextPages = await Promise.map(this.getNextPages(releases), page => this.client.repos.listReleases({ ...options, page }), { concurrency });
+    const nextPages = await Promise.map(
+      this.getNextPages(releases),
+      page => this.client.repos.listReleases({ ...options, page }),
+      { concurrency }
+    );
 
     return chain(releases.data)
       .concat(flatMap(nextPages, 'data'))

--- a/src/changelog-formatter.js
+++ b/src/changelog-formatter.js
@@ -1,4 +1,3 @@
-
 /**
  * Export `formatChangelog`.
  */
@@ -7,7 +6,9 @@ module.exports.formatChangelog = releases => {
   const changelog = ['# Changelog\n'];
 
   for (const release of releases) {
-    changelog.push(`\n## [${release.name || release.tag_name}](${release.html_url}) (${release.created_at.format('YYYY-MM-DD')})\n`);
+    changelog.push(
+      `\n## [${release.name || release.tag_name}](${release.html_url}) (${release.created_at.format('YYYY-MM-DD')})\n`
+    );
 
     for (const pr of release.prs) {
       changelog.push(`- ${pr.title} [\\#${pr.number}](${pr.html_url}) ([${pr.user.login}](${pr.user.html_url}))\n`);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -17,7 +16,10 @@ const program = require('commander');
 program
   .option('-b, --base-branch <name>', '[optional] specify the base branch name - master by default')
   .option('-f, --future-release <version>', '[optional] specify the next release version')
-  .option('-t, --future-release-tag <name>', '[optional] specify the next release tag name if it is different from the release version')
+  .option(
+    '-t, --future-release-tag <name>',
+    '[optional] specify the next release tag name if it is different from the release version'
+  )
   .option('-l, --labels <names>', '[optional] labels to filter pull requests by', val => val.split(','))
   .option('-o, --owner <name>', '[optional] owner of the repository')
   .option('-r, --repo <name>', '[optional] name of the repository')

--- a/test/changelog-fetcher.test.js
+++ b/test/changelog-fetcher.test.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -54,90 +53,108 @@ describe('ChangelogFetcher', () => {
       nock('https://api.github.com')
         .get('/repos/biz/buz/releases')
         .query({ page: 1, per_page: 100 })
-        .reply(200, [{
-          created_at: moment('2018-10-23T12'),
-          html_url: 'foo-url',
-          name: 'foo-name',
-          tag_name: 'foo-tag'
-        }, {
-          created_at: moment('2018-10-22T12'),
-          html_url: 'bar-url',
-          tag_name: 'bar-tag'
-        }]);
+        .reply(200, [
+          {
+            created_at: moment('2018-10-23T12'),
+            html_url: 'foo-url',
+            name: 'foo-name',
+            tag_name: 'foo-tag'
+          },
+          {
+            created_at: moment('2018-10-22T12'),
+            html_url: 'bar-url',
+            tag_name: 'bar-tag'
+          }
+        ]);
 
       nock('https://api.github.com')
         .get('/repos/biz/buz/pulls')
         .query({ base: 'foo', page: 1, per_page: 100, state: 'closed' })
-        .reply(200, [{
-          html_url: 'quxfoo-url',
-          merged_at: moment('2018-10-24T10'),
-          number: 'quxfoo-number',
-          title: 'quxfoo-title',
-          user: { html_url: 'quxfoo-user-url', login: 'quxfoo-user-login' }
-        }, {
-          html_url: 'foobar-url',
-          merged_at: moment('2018-10-23T10'),
-          number: 'foobar-number',
-          title: 'foobar-title',
-          user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
-        }, {
-          html_url: 'foobiz-url',
-          merged_at: moment('2018-10-22T20'),
-          number: 'foobiz-number',
-          title: 'foobiz-title',
-          user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
-        }, {
-          html_url: 'barbiz-url',
-          merged_at: moment('2018-10-22T10'),
-          number: 'barbiz-number',
-          title: 'barbiz-title',
-          user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
-        }, {
-          html_url: 'barbuz-url',
-          merged_at: moment('2018-10-21T05'),
-          number: 'barbuz-number',
-          title: 'barbuz-title',
-          user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
-        }]);
+        .reply(200, [
+          {
+            html_url: 'quxfoo-url',
+            merged_at: moment('2018-10-24T10'),
+            number: 'quxfoo-number',
+            title: 'quxfoo-title',
+            user: { html_url: 'quxfoo-user-url', login: 'quxfoo-user-login' }
+          },
+          {
+            html_url: 'foobar-url',
+            merged_at: moment('2018-10-23T10'),
+            number: 'foobar-number',
+            title: 'foobar-title',
+            user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
+          },
+          {
+            html_url: 'foobiz-url',
+            merged_at: moment('2018-10-22T20'),
+            number: 'foobiz-number',
+            title: 'foobiz-title',
+            user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
+          },
+          {
+            html_url: 'barbiz-url',
+            merged_at: moment('2018-10-22T10'),
+            number: 'barbiz-number',
+            title: 'barbiz-title',
+            user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
+          },
+          {
+            html_url: 'barbuz-url',
+            merged_at: moment('2018-10-21T05'),
+            number: 'barbuz-number',
+            title: 'barbuz-title',
+            user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
+          }
+        ]);
 
       const releases = await fetcher.fetchChangelog();
 
-      expect(releases).toEqual([{
-        created_at: expect.any(moment),
-        html_url: 'foo-url',
-        name: 'foo-name',
-        prs: [{
-          html_url: 'foobar-url',
-          merged_at: expect.any(moment),
-          number: 'foobar-number',
-          title: 'foobar-title',
-          user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
-        }, {
-          html_url: 'foobiz-url',
-          merged_at: expect.any(moment),
-          number: 'foobiz-number',
-          title: 'foobiz-title',
-          user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
-        }],
-        tag_name: 'foo-tag'
-      }, {
-        created_at: expect.any(moment),
-        html_url: 'bar-url',
-        prs: [{
-          html_url: 'barbiz-url',
-          merged_at: expect.any(moment),
-          number: 'barbiz-number',
-          title: 'barbiz-title',
-          user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
-        }, {
-          html_url: 'barbuz-url',
-          merged_at: expect.any(moment),
-          number: 'barbuz-number',
-          title: 'barbuz-title',
-          user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
-        }],
-        tag_name: 'bar-tag'
-      }]);
+      expect(releases).toEqual([
+        {
+          created_at: expect.any(moment),
+          html_url: 'foo-url',
+          name: 'foo-name',
+          prs: [
+            {
+              html_url: 'foobar-url',
+              merged_at: expect.any(moment),
+              number: 'foobar-number',
+              title: 'foobar-title',
+              user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
+            },
+            {
+              html_url: 'foobiz-url',
+              merged_at: expect.any(moment),
+              number: 'foobiz-number',
+              title: 'foobiz-title',
+              user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
+            }
+          ],
+          tag_name: 'foo-tag'
+        },
+        {
+          created_at: expect.any(moment),
+          html_url: 'bar-url',
+          prs: [
+            {
+              html_url: 'barbiz-url',
+              merged_at: expect.any(moment),
+              number: 'barbiz-number',
+              title: 'barbiz-title',
+              user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
+            },
+            {
+              html_url: 'barbuz-url',
+              merged_at: expect.any(moment),
+              number: 'barbuz-number',
+              title: 'barbuz-title',
+              user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
+            }
+          ],
+          tag_name: 'bar-tag'
+        }
+      ]);
     });
 
     it('should add a new release based on `futureRelease`', async () => {
@@ -152,56 +169,68 @@ describe('ChangelogFetcher', () => {
       nock('https://api.github.com')
         .get('/repos/biz/buz/releases')
         .query({ page: 1, per_page: 100 })
-        .reply(200, [{
-          created_at: moment('2018-10-23T12'),
-          html_url: 'foo-url',
-          name: 'foo-name',
-          tag_name: 'foo-tag'
-        }]);
+        .reply(200, [
+          {
+            created_at: moment('2018-10-23T12'),
+            html_url: 'foo-url',
+            name: 'foo-name',
+            tag_name: 'foo-tag'
+          }
+        ]);
 
       nock('https://api.github.com')
         .get('/repos/biz/buz/pulls')
         .query({ base: 'foo', page: 1, per_page: 100, state: 'closed' })
-        .reply(200, [{
-          html_url: 'foobar-url',
-          merged_at: moment('2018-10-23T16'),
-          number: 'foobar-number',
-          title: 'foobar-title',
-          user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
-        }, {
-          html_url: 'foobiz-url',
-          merged_at: moment('2018-10-22T20'),
-          number: 'foobiz-number',
-          title: 'foobiz-title',
-          user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
-        }]);
+        .reply(200, [
+          {
+            html_url: 'foobar-url',
+            merged_at: moment('2018-10-23T16'),
+            number: 'foobar-number',
+            title: 'foobar-title',
+            user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
+          },
+          {
+            html_url: 'foobiz-url',
+            merged_at: moment('2018-10-22T20'),
+            number: 'foobiz-number',
+            title: 'foobiz-title',
+            user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
+          }
+        ]);
 
       const releases = await fetcher.fetchChangelog();
 
-      expect(releases).toEqual([{
-        created_at: expect.any(moment),
-        html_url: 'https://github.com/biz/buz/releases/tag/bar',
-        name: 'bar',
-        prs: [{
-          html_url: 'foobar-url',
-          merged_at: expect.any(moment),
-          number: 'foobar-number',
-          title: 'foobar-title',
-          user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
-        }]
-      }, {
-        created_at: expect.any(moment),
-        html_url: 'foo-url',
-        name: 'foo-name',
-        prs: [{
-          html_url: 'foobiz-url',
-          merged_at: expect.any(moment),
-          number: 'foobiz-number',
-          title: 'foobiz-title',
-          user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
-        }],
-        tag_name: 'foo-tag'
-      }]);
+      expect(releases).toEqual([
+        {
+          created_at: expect.any(moment),
+          html_url: 'https://github.com/biz/buz/releases/tag/bar',
+          name: 'bar',
+          prs: [
+            {
+              html_url: 'foobar-url',
+              merged_at: expect.any(moment),
+              number: 'foobar-number',
+              title: 'foobar-title',
+              user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
+            }
+          ]
+        },
+        {
+          created_at: expect.any(moment),
+          html_url: 'foo-url',
+          name: 'foo-name',
+          prs: [
+            {
+              html_url: 'foobiz-url',
+              merged_at: expect.any(moment),
+              number: 'foobiz-number',
+              title: 'foobiz-title',
+              user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
+            }
+          ],
+          tag_name: 'foo-tag'
+        }
+      ]);
     });
 
     it('should handle pagination correctly', async () => {
@@ -215,102 +244,137 @@ describe('ChangelogFetcher', () => {
       nock('https://api.github.com')
         .get('/repos/biz/buz/releases')
         .query({ page: 1, per_page: 100 })
-        .reply(200, [{
-          created_at: moment('2018-10-23T12'),
-          html_url: 'foo-url',
-          name: 'foo-name',
-          tag_name: 'foo-tag'
-        }], {
-          link: '<foo&page=2&per_page=100>; rel="last"'
-        });
+        .reply(
+          200,
+          [
+            {
+              created_at: moment('2018-10-23T12'),
+              html_url: 'foo-url',
+              name: 'foo-name',
+              tag_name: 'foo-tag'
+            }
+          ],
+          {
+            link: '<foo&page=2&per_page=100>; rel="last"'
+          }
+        );
 
       nock('https://api.github.com')
         .get('/repos/biz/buz/releases')
         .query({ page: 2, per_page: 100 })
-        .reply(200, [{
-          created_at: moment('2018-10-22T12'),
-          html_url: 'bar-url',
-          tag_name: 'bar-tag'
-        }], {
-          link: '<foo&page=2&per_page=100>; rel="last"'
-        });
+        .reply(
+          200,
+          [
+            {
+              created_at: moment('2018-10-22T12'),
+              html_url: 'bar-url',
+              tag_name: 'bar-tag'
+            }
+          ],
+          {
+            link: '<foo&page=2&per_page=100>; rel="last"'
+          }
+        );
 
       nock('https://api.github.com')
         .get('/repos/biz/buz/pulls')
         .query({ base: 'foo', page: 1, per_page: 100, state: 'closed' })
-        .reply(200, [{
-          html_url: 'foobar-url',
-          merged_at: moment('2018-10-23T10'),
-          number: 'foobar-number',
-          title: 'foobar-title',
-          user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
-        }, {
-          html_url: 'foobiz-url',
-          merged_at: moment('2018-10-22T20'),
-          number: 'foobiz-number',
-          title: 'foobiz-title',
-          user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
-        }, {
-          html_url: 'barbiz-url',
-          merged_at: moment('2018-10-22T10'),
-          number: 'barbiz-number',
-          title: 'barbiz-title',
-          user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
-        }], {
-          link: '<foo&page=2&per_page=100>; rel="last"'
-        });
+        .reply(
+          200,
+          [
+            {
+              html_url: 'foobar-url',
+              merged_at: moment('2018-10-23T10'),
+              number: 'foobar-number',
+              title: 'foobar-title',
+              user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
+            },
+            {
+              html_url: 'foobiz-url',
+              merged_at: moment('2018-10-22T20'),
+              number: 'foobiz-number',
+              title: 'foobiz-title',
+              user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
+            },
+            {
+              html_url: 'barbiz-url',
+              merged_at: moment('2018-10-22T10'),
+              number: 'barbiz-number',
+              title: 'barbiz-title',
+              user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
+            }
+          ],
+          {
+            link: '<foo&page=2&per_page=100>; rel="last"'
+          }
+        );
 
       nock('https://api.github.com')
         .get('/repos/biz/buz/pulls')
         .query({ base: 'foo', page: 2, per_page: 100, state: 'closed' })
-        .reply(200, [{
-          html_url: 'barbuz-url',
-          merged_at: moment('2018-10-21T05'),
-          number: 'barbuz-number',
-          title: 'barbuz-title',
-          user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
-        }], {
-          link: '<foo&page=2&per_page=100>; rel="last"'
-        });
+        .reply(
+          200,
+          [
+            {
+              html_url: 'barbuz-url',
+              merged_at: moment('2018-10-21T05'),
+              number: 'barbuz-number',
+              title: 'barbuz-title',
+              user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
+            }
+          ],
+          {
+            link: '<foo&page=2&per_page=100>; rel="last"'
+          }
+        );
 
       const releases = await fetcher.fetchChangelog();
 
-      expect(releases).toEqual([{
-        created_at: expect.any(moment),
-        html_url: 'foo-url',
-        name: 'foo-name',
-        prs: [{
-          html_url: 'foobar-url',
-          merged_at: expect.any(moment),
-          number: 'foobar-number',
-          title: 'foobar-title',
-          user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
-        }, {
-          html_url: 'foobiz-url',
-          merged_at: expect.any(moment),
-          number: 'foobiz-number',
-          title: 'foobiz-title',
-          user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
-        }],
-        tag_name: 'foo-tag'
-      }, {
-        created_at: expect.any(moment),
-        html_url: 'bar-url',
-        prs: [{
-          html_url: 'barbiz-url',
-          merged_at: expect.any(moment),
-          number: 'barbiz-number',
-          title: 'barbiz-title',
-          user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
-        }, {
-          html_url: 'barbuz-url',
-          merged_at: expect.any(moment),
-          number: 'barbuz-number',
-          title: 'barbuz-title',
-          user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
-        }],
-        tag_name: 'bar-tag'
-      }]);
+      expect(releases).toEqual([
+        {
+          created_at: expect.any(moment),
+          html_url: 'foo-url',
+          name: 'foo-name',
+          prs: [
+            {
+              html_url: 'foobar-url',
+              merged_at: expect.any(moment),
+              number: 'foobar-number',
+              title: 'foobar-title',
+              user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
+            },
+            {
+              html_url: 'foobiz-url',
+              merged_at: expect.any(moment),
+              number: 'foobiz-number',
+              title: 'foobiz-title',
+              user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
+            }
+          ],
+          tag_name: 'foo-tag'
+        },
+        {
+          created_at: expect.any(moment),
+          html_url: 'bar-url',
+          prs: [
+            {
+              html_url: 'barbiz-url',
+              merged_at: expect.any(moment),
+              number: 'barbiz-number',
+              title: 'barbiz-title',
+              user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
+            },
+            {
+              html_url: 'barbuz-url',
+              merged_at: expect.any(moment),
+              number: 'barbuz-number',
+              title: 'barbuz-title',
+              user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
+            }
+          ],
+          tag_name: 'bar-tag'
+        }
+      ]);
     });
 
     it('should filter pull requests by the given list of labels', async () => {
@@ -325,90 +389,105 @@ describe('ChangelogFetcher', () => {
       nock('https://api.github.com')
         .get('/repos/biz/buz/releases')
         .query({ page: 1, per_page: 100 })
-        .reply(200, [{
-          created_at: moment('2018-10-23T12'),
-          html_url: 'foo-url',
-          name: 'foo-name',
-          tag_name: 'foo-tag'
-        }]);
+        .reply(200, [
+          {
+            created_at: moment('2018-10-23T12'),
+            html_url: 'foo-url',
+            name: 'foo-name',
+            tag_name: 'foo-tag'
+          }
+        ]);
 
       nock('https://api.github.com')
         .get('/repos/biz/buz/pulls')
         .query({ base: 'foo', page: 1, per_page: 100, state: 'closed' })
-        .reply(200, [{
-          html_url: 'quxfoo-url',
-          labels: [{ name: 'fizz' }],
-          merged_at: moment('2018-10-23T10'),
-          number: 'quxfoo-number',
-          title: 'quxfoo-title',
-          user: { html_url: 'quxfoo-user-url', login: 'quxfoo-user-login' }
-        }, {
-          html_url: 'foobar-url',
-          labels: [{ name: 'bar' }],
-          merged_at: moment('2018-10-22T10'),
-          number: 'foobar-number',
-          title: 'foobar-title',
-          user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
-        }, {
-          html_url: 'foobiz-url',
-          labels: [{ name: 'fuzz' }],
-          merged_at: moment('2018-10-21T20'),
-          number: 'foobiz-number',
-          title: 'foobiz-title',
-          user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
-        }, {
-          html_url: 'barbiz-url',
-          labels: [{ name: 'fizz' }, { name: 'bar' }],
-          merged_at: moment('2018-10-20T10'),
-          number: 'barbiz-number',
-          title: 'barbiz-title',
-          user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
-        }, {
-          html_url: 'barbuz-url',
-          labels: [{ name: 'bar' }, { name: 'baz' }],
-          merged_at: moment('2018-10-19T10'),
-          number: 'barbuz-number',
-          title: 'barbuz-title',
-          user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
-        }, {
-          html_url: 'foobuz-url',
-          labels: [],
-          merged_at: moment('2018-10-19T10'),
-          number: 'foobuz-number',
-          title: 'foobuz-title',
-          user: { html_url: 'foobuz-user-url', login: 'foobuz-user-login' }
-        }]);
+        .reply(200, [
+          {
+            html_url: 'quxfoo-url',
+            labels: [{ name: 'fizz' }],
+            merged_at: moment('2018-10-23T10'),
+            number: 'quxfoo-number',
+            title: 'quxfoo-title',
+            user: { html_url: 'quxfoo-user-url', login: 'quxfoo-user-login' }
+          },
+          {
+            html_url: 'foobar-url',
+            labels: [{ name: 'bar' }],
+            merged_at: moment('2018-10-22T10'),
+            number: 'foobar-number',
+            title: 'foobar-title',
+            user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
+          },
+          {
+            html_url: 'foobiz-url',
+            labels: [{ name: 'fuzz' }],
+            merged_at: moment('2018-10-21T20'),
+            number: 'foobiz-number',
+            title: 'foobiz-title',
+            user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
+          },
+          {
+            html_url: 'barbiz-url',
+            labels: [{ name: 'fizz' }, { name: 'bar' }],
+            merged_at: moment('2018-10-20T10'),
+            number: 'barbiz-number',
+            title: 'barbiz-title',
+            user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
+          },
+          {
+            html_url: 'barbuz-url',
+            labels: [{ name: 'bar' }, { name: 'baz' }],
+            merged_at: moment('2018-10-19T10'),
+            number: 'barbuz-number',
+            title: 'barbuz-title',
+            user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
+          },
+          {
+            html_url: 'foobuz-url',
+            labels: [],
+            merged_at: moment('2018-10-19T10'),
+            number: 'foobuz-number',
+            title: 'foobuz-title',
+            user: { html_url: 'foobuz-user-url', login: 'foobuz-user-login' }
+          }
+        ]);
 
       const releases = await fetcher.fetchChangelog();
 
-      expect(releases).toEqual([{
-        created_at: expect.any(moment),
-        html_url: 'foo-url',
-        name: 'foo-name',
-        prs: [{
-          html_url: 'quxfoo-url',
-          labels: [{ name: 'fizz' }],
-          merged_at: expect.any(moment),
-          number: 'quxfoo-number',
-          title: 'quxfoo-title',
-          user: { html_url: 'quxfoo-user-url', login: 'quxfoo-user-login' }
-        }, {
-          html_url: 'foobiz-url',
-          labels: [{ name: 'fuzz' }],
-          merged_at: expect.any(moment),
-          number: 'foobiz-number',
-          title: 'foobiz-title',
-          user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
-        }, {
-          html_url: 'barbiz-url',
-          labels: [{ name: 'fizz' }, { name: 'bar' }],
-          merged_at: expect.any(moment),
-          number: 'barbiz-number',
-          title: 'barbiz-title',
-          user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
-        }],
-        tag_name: 'foo-tag'
-      }]);
+      expect(releases).toEqual([
+        {
+          created_at: expect.any(moment),
+          html_url: 'foo-url',
+          name: 'foo-name',
+          prs: [
+            {
+              html_url: 'quxfoo-url',
+              labels: [{ name: 'fizz' }],
+              merged_at: expect.any(moment),
+              number: 'quxfoo-number',
+              title: 'quxfoo-title',
+              user: { html_url: 'quxfoo-user-url', login: 'quxfoo-user-login' }
+            },
+            {
+              html_url: 'foobiz-url',
+              labels: [{ name: 'fuzz' }],
+              merged_at: expect.any(moment),
+              number: 'foobiz-number',
+              title: 'foobiz-title',
+              user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
+            },
+            {
+              html_url: 'barbiz-url',
+              labels: [{ name: 'fizz' }, { name: 'bar' }],
+              merged_at: expect.any(moment),
+              number: 'barbiz-number',
+              title: 'barbiz-title',
+              user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
+            }
+          ],
+          tag_name: 'foo-tag'
+        }
+      ]);
     });
   });
 });

--- a/test/changelog-formatter.test.js
+++ b/test/changelog-formatter.test.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -13,38 +12,47 @@ const moment = require('moment');
 describe('ChangelogFormatter', () => {
   describe('formatChangelog()', () => {
     it('should return an array of lines for releases and pull requests in the expected format', () => {
-      const releases = [{
-        created_at: moment('2018-10-23'),
-        html_url: 'foo-url',
-        name: 'foo-name',
-        prs: [{
-          html_url: 'foobar-url',
-          number: 'foobar-number',
-          title: 'foobar-title',
-          user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
-        }, {
-          html_url: 'foobiz-url',
-          number: 'foobiz-number',
-          title: 'foobiz-title',
-          user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
-        }],
-        tag_name: 'foo-tag'
-      }, {
-        created_at: moment('2018-10-22'),
-        html_url: 'bar-url',
-        prs: [{
-          html_url: 'barbiz-url',
-          number: 'barbiz-number',
-          title: 'barbiz-title',
-          user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
-        }, {
-          html_url: 'barbuz-url',
-          number: 'barbuz-number',
-          title: 'barbuz-title',
-          user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
-        }],
-        tag_name: 'bar-tag'
-      }];
+      const releases = [
+        {
+          created_at: moment('2018-10-23'),
+          html_url: 'foo-url',
+          name: 'foo-name',
+          prs: [
+            {
+              html_url: 'foobar-url',
+              number: 'foobar-number',
+              title: 'foobar-title',
+              user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
+            },
+            {
+              html_url: 'foobiz-url',
+              number: 'foobiz-number',
+              title: 'foobiz-title',
+              user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
+            }
+          ],
+          tag_name: 'foo-tag'
+        },
+        {
+          created_at: moment('2018-10-22'),
+          html_url: 'bar-url',
+          prs: [
+            {
+              html_url: 'barbiz-url',
+              number: 'barbiz-number',
+              title: 'barbiz-title',
+              user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
+            },
+            {
+              html_url: 'barbuz-url',
+              number: 'barbuz-number',
+              title: 'barbuz-title',
+              user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
+            }
+          ],
+          tag_name: 'bar-tag'
+        }
+      ];
 
       expect(formatChangelog(releases)).toEqual([
         '# Changelog\n',

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,9 +109,10 @@ acorn-globals@^4.1.0:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
-acorn-jsx@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.0.tgz#958584ddb60990c02c97c1bd9d521fce433bb101"
+acorn-jsx@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.2.tgz#84b68ea44b373c4f8686023a551f61a21b7c4a4f"
+  integrity sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==
 
 acorn-walk@^6.0.1:
   version "6.1.0"
@@ -121,9 +122,14 @@ acorn@^5.5.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
 
-acorn@^6.0.1, acorn@^6.0.2:
+acorn@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.2.tgz#6a459041c320ab17592c6317abbfdf4bbaa98ca4"
+
+acorn@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
+  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
 
 agent-base@4, agent-base@^4.1.0:
   version "4.2.1"
@@ -140,9 +146,10 @@ ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.5.3:
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.4.tgz#247d5274110db653706b550fcc2b797ca28cfc59"
+ajv@^6.10.0, ajv@^6.10.2:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
+  integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -153,6 +160,11 @@ ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
+ansi-escapes@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
+  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
+
 ansi-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.0.0.tgz#c5061b6e0ef8a81775e50f5d66151bf6bf371107"
@@ -160,6 +172,11 @@ ansi-regex@^2.0.0:
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -234,16 +251,6 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
-array-union@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
-  dependencies:
-    array-uniq "^1.0.1"
-
-array-uniq@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
-
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
@@ -252,7 +259,7 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
-arrify@^1.0.0, arrify@^1.0.1:
+arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
@@ -327,7 +334,7 @@ babel-cli@^6.26.0:
   optionalDependencies:
     chokidar "^1.6.1"
 
-babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
+babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -370,14 +377,17 @@ babel-eslint@^10.0.1:
     eslint-scope "3.7.1"
     eslint-visitor-keys "^1.0.0"
 
-babel-eslint@^7.1.1:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
+babel-eslint@^10.0.2:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.3.tgz#81a2c669be0f205e19462fed2482d33e4687a88a"
+  integrity sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==
   dependencies:
-    babel-code-frame "^6.22.0"
-    babel-traverse "^6.23.1"
-    babel-types "^6.23.0"
-    babylon "^6.17.0"
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-visitor-keys "^1.0.0"
+    resolve "^1.12.0"
 
 babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.1"
@@ -554,7 +564,7 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -568,7 +578,7 @@ babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-tra
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -577,7 +587,7 @@ babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.23.0, babel-types@^6.24.
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@^6.17.0, babylon@^6.18.0:
+babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
@@ -702,19 +712,14 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-caller-path@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
-  dependencies:
-    callsites "^0.2.0"
-
-callsites@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
-
 callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
+
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 camelcase@^4.1.0:
   version "4.1.0"
@@ -759,6 +764,15 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -789,10 +803,6 @@ chownr@^1.0.1:
 ci-info@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
-
-circular-json@^0.3.1:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -1026,18 +1036,6 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-del@^2.0.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
-  dependencies:
-    globby "^5.0.0"
-    is-path-cwd "^1.0.0"
-    is-path-in-cwd "^1.0.0"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-    rimraf "^2.2.8"
-
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -1064,9 +1062,10 @@ diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
-doctrine@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
 
@@ -1081,6 +1080,11 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
 error-ex@^1.2.0:
   version "1.3.2"
@@ -1131,25 +1135,38 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-uphold@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-uphold/-/eslint-config-uphold-0.2.0.tgz#3fd7a26ed33cc167e5ed1a41196bc8d6dde957f1"
+eslint-config-prettier@^6.0.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.4.0.tgz#0a04f147e31d33c6c161b2dd0971418ac52d0477"
+  integrity sha512-YrKucoFdc7SEko5Sxe4r6ixqXPDP1tunGw91POeZTTRKItf/AMFYt/YLEQtZMkR2LVpAVhcAcZgcWpm1oGPW7w==
   dependencies:
-    babel-eslint "^7.1.1"
-    eslint-plugin-mocha "^5.1.0"
-    eslint-plugin-sort-class-members "^1.0.1"
+    get-stdin "^6.0.0"
+
+eslint-config-uphold@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-uphold/-/eslint-config-uphold-1.0.0.tgz#2ced07afeb159e33dc502ae5977401c032e17272"
+  integrity sha512-jZn1GonpQD1cnrB3zIj7CjTtALr18t8p1tUqitJ3oZuHtGQKE05b8NYDluxL0IJ9WtlLZgX/mr8yjf4DRxGFDQ==
+  dependencies:
+    babel-eslint "^10.0.2"
+    eslint-config-prettier "^6.0.0"
+    eslint-plugin-mocha "^5.3.0"
+    eslint-plugin-prettier "^3.1.0"
     eslint-plugin-sort-imports-es6 "^0.0.3"
     eslint-plugin-sql-template "^2.0.0"
 
-eslint-plugin-mocha@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-5.2.0.tgz#d8786d9fff8cb8b5f6e4b61e40395d6568a5c4e2"
+eslint-plugin-mocha@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-5.3.0.tgz#cf3eb18ae0e44e433aef7159637095a7cb19b15b"
+  integrity sha512-3uwlJVLijjEmBeNyH60nzqgA1gacUWLUmcKV8PIGNvj1kwP/CTgAWQHn2ayyJVwziX+KETkr9opNwT1qD/RZ5A==
   dependencies:
-    ramda "^0.25.0"
+    ramda "^0.26.1"
 
-eslint-plugin-sort-class-members@^1.0.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.4.0.tgz#71295d127752131e798ed1e5e76970f2c2c3ae48"
+eslint-plugin-prettier@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz#507b8562410d02a03f0ddc949c616f877852f2ba"
+  integrity sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-sort-imports-es6@^0.0.3:
   version "0.0.3"
@@ -1168,71 +1185,81 @@ eslint-scope@3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
+eslint-scope@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
+  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+eslint-utils@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
+  integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
+  dependencies:
+    eslint-visitor-keys "^1.0.0"
 
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^5.8.0:
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.8.0.tgz#91fbf24f6e0471e8fdf681a4d9dd1b2c9f28309b"
+eslint-visitor-keys@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
+  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
+
+eslint@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.5.1.tgz#828e4c469697d43bb586144be152198b91e96ed6"
+  integrity sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    ajv "^6.5.3"
+    ajv "^6.10.0"
     chalk "^2.1.0"
     cross-spawn "^6.0.5"
     debug "^4.0.1"
-    doctrine "^2.1.0"
-    eslint-scope "^4.0.0"
-    eslint-utils "^1.3.1"
-    eslint-visitor-keys "^1.0.0"
-    espree "^4.0.0"
+    doctrine "^3.0.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^1.4.2"
+    eslint-visitor-keys "^1.1.0"
+    espree "^6.1.1"
     esquery "^1.0.1"
     esutils "^2.0.2"
-    file-entry-cache "^2.0.0"
+    file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
-    glob "^7.1.2"
+    glob-parent "^5.0.0"
     globals "^11.7.0"
     ignore "^4.0.6"
+    import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
-    inquirer "^6.1.0"
-    is-resolvable "^1.1.0"
-    js-yaml "^3.12.0"
+    inquirer "^6.4.1"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.17.5"
+    lodash "^4.17.14"
     minimatch "^3.0.4"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.2"
-    pluralize "^7.0.0"
     progress "^2.0.0"
     regexpp "^2.0.1"
-    require-uncached "^1.0.3"
-    semver "^5.5.1"
-    strip-ansi "^4.0.0"
-    strip-json-comments "^2.0.1"
-    table "^5.0.2"
+    semver "^6.1.2"
+    strip-ansi "^5.2.0"
+    strip-json-comments "^3.0.1"
+    table "^5.2.3"
     text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
 
-espree@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-4.1.0.tgz#728d5451e0fd156c04384a7ad89ed51ff54eb25f"
+espree@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.1.1.tgz#7f80e5f7257fc47db450022d723e356daeb1e5de"
+  integrity sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==
   dependencies:
-    acorn "^6.0.2"
-    acorn-jsx "^5.0.0"
-    eslint-visitor-keys "^1.0.0"
+    acorn "^7.0.0"
+    acorn-jsx "^5.0.2"
+    eslint-visitor-keys "^1.1.0"
 
 esprima@^3.1.3:
   version "3.1.3"
@@ -1341,9 +1368,10 @@ extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
-external-editor@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+external-editor@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
+  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
   dependencies:
     chardet "^0.7.0"
     iconv-lite "^0.4.24"
@@ -1380,6 +1408,11 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
 
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -1400,12 +1433,12 @@ figures@^2.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-file-entry-cache@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
-    flat-cache "^1.2.1"
-    object-assign "^4.0.1"
+    flat-cache "^2.0.1"
 
 filename-regex@^2.0.0:
   version "2.0.0"
@@ -1450,14 +1483,19 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-flat-cache@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
   dependencies:
-    circular-json "^0.3.1"
-    del "^2.0.2"
-    graceful-fs "^4.1.2"
-    write "^0.2.1"
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
+flatted@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
+  integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
 for-in@^0.1.5:
   version "0.1.6"
@@ -1541,6 +1579,11 @@ get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -1568,6 +1611,13 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
+glob-parent@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
+  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob@^7.0.3, glob@^7.1.1, glob@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
@@ -1590,6 +1640,18 @@ glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.3:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 globals@^11.1.0, globals@^11.7.0:
   version "11.8.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.8.0.tgz#c1ef45ee9bed6badf0663c5cb90e8d1adec1321d"
@@ -1597,17 +1659,6 @@ globals@^11.1.0, globals@^11.7.0:
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
-
-globby@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
-  dependencies:
-    array-union "^1.0.1"
-    arrify "^1.0.0"
-    glob "^7.0.3"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "4.1.11"
@@ -1749,6 +1800,14 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
 
+import-fresh@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.1.0.tgz#6d33fa1dcef6df930fae003446f33415af905118"
+  integrity sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
 import-local@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
@@ -1779,22 +1838,23 @@ ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
-inquirer@^6.1.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.0.tgz#51adcd776f661369dc1e894859c2560a224abdd8"
+inquirer@^6.4.1:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.2.tgz#ad50942375d036d327ff528c08bd5fab089928ca"
+  integrity sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==
   dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.0"
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
     cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    external-editor "^3.0.0"
+    external-editor "^3.0.3"
     figures "^2.0.0"
-    lodash "^4.17.10"
+    lodash "^4.17.12"
     mute-stream "0.0.7"
     run-async "^2.2.0"
-    rxjs "^6.1.0"
+    rxjs "^6.4.0"
     string-width "^2.1.0"
-    strip-ansi "^4.0.0"
+    strip-ansi "^5.1.0"
     through "^2.3.6"
 
 invariant@^2.2.2, invariant@^2.2.4:
@@ -1909,6 +1969,11 @@ is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+
 is-finite@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
@@ -1935,6 +2000,13 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
+is-glob@^4.0.0, is-glob@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -1950,22 +2022,6 @@ is-number@^3.0.0:
 is-number@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
-
-is-path-cwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
-
-is-path-in-cwd@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
-  dependencies:
-    is-path-inside "^1.0.0"
-
-is-path-inside@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
-  dependencies:
-    path-is-inside "^1.0.1"
 
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -1990,10 +2046,6 @@ is-regex@^1.0.4:
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
     has "^1.0.1"
-
-is-resolvable@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -2404,7 +2456,7 @@ js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-yaml@^3.12.0, js-yaml@^3.7.0:
+js-yaml@^3.13.1, js-yaml@^3.7.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -2559,7 +2611,7 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
+lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -2715,8 +2767,9 @@ minizlib@^1.1.0:
     minipass "^2.2.1"
 
 mixin-deep@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
+  integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
@@ -3024,6 +3077,13 @@ p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
 
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
+
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
@@ -3061,15 +3121,11 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1, path-is-inside@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
-
 path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
-path-parse@^1.0.5:
+path-parse@^1.0.5, path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
 
@@ -3109,10 +3165,6 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-pluralize@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
-
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
@@ -3136,6 +3188,18 @@ prelude-ls@~1.1.2:
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-format@^23.6.0:
   version "23.6.0"
@@ -3191,9 +3255,10 @@ qs@^6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
-ramda@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
+ramda@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 randomatic@^3.0.0:
   version "3.1.1"
@@ -3361,26 +3426,20 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
-require-uncached@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
-  dependencies:
-    caller-path "^0.1.0"
-    resolve-from "^1.0.0"
-
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
   dependencies:
     resolve-from "^3.0.0"
 
-resolve-from@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
-
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -3389,6 +3448,13 @@ resolve-url@^0.2.1:
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+resolve@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
+  dependencies:
+    path-parse "^1.0.6"
 
 restore-cursor@^2.0.0:
   version "2.0.0"
@@ -3401,7 +3467,14 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
-rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -3417,9 +3490,10 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
-rxjs@^6.1.0:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
+rxjs@^6.4.0:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
+  integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==
   dependencies:
     tslib "^1.9.0"
 
@@ -3456,9 +3530,14 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.3.0, semver@^5.5.0, semver@^5.5.1:
+"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.3.0, semver@^5.5.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+
+semver@^6.1.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -3478,8 +3557,9 @@ set-value@^0.4.3:
     to-object-path "^0.3.0"
 
 set-value@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
+  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
   dependencies:
     extend-shallow "^2.0.1"
     is-extendable "^0.1.1"
@@ -3512,10 +3592,13 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-slice-ansi@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+slice-ansi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
   dependencies:
+    ansi-styles "^3.2.0"
+    astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
 snapdragon-node@^2.0.1:
@@ -3674,6 +3757,15 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
+
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -3696,6 +3788,13 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
+
 strip-bom@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -3710,7 +3809,12 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
-strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
+  integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
+
+strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -3734,14 +3838,15 @@ symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
-table@^5.0.2:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.1.0.tgz#69a54644f6f01ad1628f8178715b408dc6bf11f7"
+table@^5.2.3:
+  version "5.4.6"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
+  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
   dependencies:
-    ajv "^6.5.3"
-    lodash "^4.17.10"
-    slice-ansi "1.0.0"
-    string-width "^2.1.1"
+    ajv "^6.10.2"
+    lodash "^4.17.14"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
 
 tar@^4:
   version "4.4.6"
@@ -3928,6 +4033,11 @@ uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
+v8-compile-cache@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
+  integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
+
 v8flags@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"
@@ -4051,9 +4161,10 @@ write-file-atomic@^2.1.0:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-write@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
   dependencies:
     mkdirp "^0.5.1"
 


### PR DESCRIPTION
Update dependencies to fix reported security issues.

This includes a bump to our eslint config, which introduces prettier, hence the code formatting changes.

Also drops support for node 6, since the updated eslint version no longer supports it.