### PR TITLE
Improve Changelog generation performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ $ github-changelog-generator --help
     -l, --labels <names>             [optional] labels to filter pull requests by
     -o, --owner <name>               [optional] owner of the repository
     -r, --repo <name>                [optional] name of the repository
+    --rebuild                        rebuild the full changelog
 ```
 
 To generate a changelog for your GitHub project, use the following command:
 
 ```sh
-$ github-changelog-generator --base-branch=<base> --future-release=<release_name> --future-release-tag=<release_tag_name> --owner=<repo_owner> --repo=<repo_name> > <your_changelog_file>
+$ echo "$(github-changelog-generator --base-branch=<base> --future-release=<release_name> --future-release-tag=<release_tag_name> --owner=<repo_owner> --repo=<repo_name>)$(tail -n +1 <your_changelog_file>)" > <your_changelog_file>
 ```
 
 The `--base-branch` option allows you to filter the PRs by base branch. If omitted, it will default to branch master.
@@ -39,7 +40,7 @@ The `--base-branch` option allows you to filter the PRs by base branch. If omitt
 Example:
 
 ```sh
-$ github-changelog-generator --base-branch=production > CHANGELOG.md
+$ echo "$(github-changelog-generator --base-branch=production)$(tail -n +1 CHANGELOG.md)" > CHANGELOG.md
 ```
 
 The `--future-release` and `--future-release-tag` options are optional. If you just want to build a new changelog without a new release, you can skip those options, and `github-changelog-generator` will create a changelog for existing releases only. Also, if your future release tag name is the same as your future release version number, then you can skip `--future-release-tag`.
@@ -47,7 +48,7 @@ The `--future-release` and `--future-release-tag` options are optional. If you j
 Example:
 
 ```sh
-$ github-changelog-generator --future-release=1.2.3 --future-release-tag=v1.2.3 > CHANGELOG.md
+$ echo "$(github-changelog-generator --future-release=1.2.3 --future-release-tag=v1.2.3)$(tail -n +1 CHANGELOG.md)" > CHANGELOG.md
 ```
 
 The `--owner` and `--repo` options allow you to specify the owner and name of the GitHub repository, respectively. If omitted, they will default to the values found in the project's git config.
@@ -55,7 +56,7 @@ The `--owner` and `--repo` options allow you to specify the owner and name of th
 Example:
 
 ```sh
-$ github-changelog-generator --owner=uphold --repo=github-changelog-generator > CHANGELOG.md
+$ echo "$(github-changelog-generator --owner=uphold --repo=github-changelog-generator)$(tail -n +1 CHANGELOG.md)" > CHANGELOG.md
 ```
 
 The `--labels` option allows you to filter what pull requests are used by their labels. This is useful for repositories with more than one project, by labeling each pull request by what project they belong to, generating a changelog for each project becomes as simple as:
@@ -63,7 +64,17 @@ The `--labels` option allows you to filter what pull requests are used by their 
 Example:
 
 ```sh
-$ github-changelog-generator --labels projectX,general > CHANGELOG.md
+$ echo "$(github-changelog-generator --labels projectX,general)$(tail -n +1 CHANGELOG.md)" > CHANGELOG.md
+```
+
+The `--rebuild` option allows you to fetch the repository's full changelog history. 
+Starting on major version 2, the default behavior for the generator is to only create the changelog for the pull requests that come after the latest release,
+so this option allows for backwards compatibility.
+
+Example:
+
+```sh
+$ github-changelog-generator --rebuild > CHANGELOG.md
 ```
 
 ## Release

--- a/package.json
+++ b/package.json
@@ -10,17 +10,16 @@
   },
   "repository": "uphold/github-changelog-generator",
   "scripts": {
-    "changelog": "./bin/github-changelog-generator.js -f $npm_package_version -t v$npm_package_version > CHANGELOG.md",
+    "changelog": "echo \"$(./bin/github-changelog-generator.js -f $npm_package_version -t v$npm_package_version)$(tail -n +1 CHANGELOG.md)\" > CHANGELOG.md",
     "lint": "eslint --cache src test",
     "release": "npm version -m 'Release %s'",
     "test": "jest",
     "version": "npm run changelog && git add -A CHANGELOG.md"
   },
   "dependencies": {
-    "@octokit/rest": "^16.34.1",
+    "@octokit/graphql": "^4.6.1",
     "commander": "^2.19.0",
     "ini": "^1.3.5",
-    "lodash": "^4.17.15",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/src/changelog-fetcher.js
+++ b/src/changelog-fetcher.js
@@ -4,8 +4,7 @@
  * Module dependencies.
  */
 
-const _ = require('lodash');
-const Octokit = require('@octokit/rest');
+const { graphql } = require('@octokit/graphql');
 const moment = require('moment');
 
 /**
@@ -21,94 +20,278 @@ class ChangelogFetcher {
     this.base = base;
     this.futureRelease = futureRelease;
     this.futureReleaseTag = futureReleaseTag || futureRelease;
-    this.labels = labels;
+    this.labels = labels || [];
     this.owner = owner;
     this.repo = repo;
-    this.client = new Octokit({
-      auth: `token ${token}`
+    this.client = graphql.defaults({ headers: { authorization: `token ${token}` } });
+  }
+
+  /**
+   * Fetch the full changelog.
+   *
+   * @return {Array} releases - An array of objects with information about the all releases
+   */
+  async fetchFullChangelog() {
+    // Get the date the repository was created.
+    const repositoryCreatedAt = await this.getRepositoryCreatedAt();
+
+    // Get all releases.
+    const releases = await this.getReleases();
+
+    // Get all pull requests.
+    const pullRequests = await this.getPullRequestsStartingFrom(repositoryCreatedAt);
+
+    let cursor = 0;
+
+    for (const pullRequest of pullRequests) {
+      const mergedAt = moment.utc(pullRequest.mergedAt);
+
+      let isAfterNextRelease = !releases[cursor + 1] || mergedAt.isAfter(releases[cursor + 1].createdAt);
+
+      while (!isAfterNextRelease) {
+        cursor += 1;
+        isAfterNextRelease = !releases[cursor + 1] || mergedAt.isAfter(releases[cursor + 1].createdAt);
+      }
+
+      const isBeforeCurrentRelease = mergedAt.isSameOrBefore(releases[cursor].createdAt);
+
+      if (isBeforeCurrentRelease) {
+        releases[cursor].pullRequests.push(pullRequest);
+      }
+    }
+
+    return releases;
+  }
+
+  /**
+   * Fetch changelog after the latest release.
+   *
+   * @return {Array} releases - An array with an object with information about the latest release
+   */
+  async fetchLatestChangelog() {
+    // Don't do anything if a futureRelease was not specified.
+    if (!this.futureRelease) {
+      return [];
+    }
+
+    // Get the latest release.
+    const latestRelease = await this.getLatestRelease();
+
+    if (latestRelease.tagName === this.futureReleaseTag) {
+      throw new Error('Changelog already on the latest release');
+    }
+
+    // Get PRs up to the last release commit date.
+    const pullRequests = await this.getPullRequestsStartingFrom(latestRelease.tagCommit.committedDate);
+
+    return [
+      {
+        createdAt: moment.utc(),
+        name: this.futureRelease,
+        pullRequests,
+        url: `https://github.com/${this.owner}/${this.repo}/releases/tag/${this.futureReleaseTag}`
+      }
+    ];
+  }
+
+  /**
+   * Get the latest release.
+   *
+   * @return {Object} release - the latest release
+   */
+  async getLatestRelease() {
+    const query = `
+    query latestRelease($owner: String!, $repo: String!) {
+      repository(owner: $owner, name: $repo){
+        latestRelease {
+          tagCommit {
+            committedDate
+          }
+          tagName
+        }
+      }
+    }`;
+    const result = await this.client(query, { owner: this.owner, repo: this.repo });
+
+    // Extract release from nested result.
+    const release = result.repository.latestRelease;
+
+    // Transform string timestamp into moment.
+    release.tagCommit.committedDate = moment.utc(release.tagCommit.committedDate);
+
+    return release;
+  }
+
+  /**
+   * Auxiliary function to iterage through list of PRs.
+   *
+   * @param {String} cursor - the cursor from where the function will get the PRs
+   * @param {Number} pageSize - the number of results we try to fetch each time
+   * @return {Map} {cursor, hasMoreResults, pullRequests} - An array of maps with information about the last PRs
+   *                                                        starting from cursor (from newest to oldest)
+   */
+  async getPullRequestsQuery(cursor = '', pageSize = 30) {
+    const [cursorSignature, cursorParam] = cursor ? [', $cursor: String!', ', after: $cursor'] : ['', ''];
+
+    const [labelsSignature, labelsParam] =
+      this.labels.length === 0 ? ['', ''] : [', $labels: [String!]', ', labels: $labels'];
+
+    // TODO: replace orderBy from UPDATED_AT to MERGED_AT when available.
+    const query = `
+      query pullRequestsBefore($owner: String!, $repo: String!, $first: Int!, $base: String!${cursorSignature}${labelsSignature}) {
+        repository(owner: $owner, name: $repo) {
+          pullRequests(baseRefName: $base,  first: $first, orderBy: {field: UPDATED_AT, direction: DESC}, states: [MERGED]${cursorParam}${labelsParam}) {
+            nodes {
+              mergedAt
+              title
+              number
+              updatedAt
+              url
+              baseRefName
+              author{
+                login
+                url
+              }
+            }
+            pageInfo {
+              endCursor
+              hasNextPage
+            }
+          }
+        }
+      }`;
+    const result = await this.client(query, {
+      base: this.base,
+      cursor,
+      first: pageSize,
+      labels: this.labels,
+      owner: this.owner,
+      repo: this.repo
     });
+
+    return {
+      cursor: result.repository.pullRequests.pageInfo.endCursor,
+      hasMoreResults: result.repository.pullRequests.pageInfo.hasNextPage,
+      pullRequests: result.repository.pullRequests.nodes
+    };
   }
 
   /**
-   * Assign pull request to release.
+   * Get the list of approved pull requests merged after a given timestamp.
+   *
+   * @param {moment} startDate - the timestamp of the release after which we want to retrieve the pull requests
+   * @return {Array} pullRequests - An array of maps with information about the pull requests
    */
+  async getPullRequestsStartingFrom(startDate) {
+    const result = [];
+    let stop = false;
+    let hasMoreResults = true;
+    let cursor = '';
+    let pullRequests = [];
 
-  assignPullRequestToRelease(releases, pr) {
-    const release = releases.find(release => pr.merged_at.isSameOrBefore(release.created_at));
+    while (!stop && hasMoreResults) {
+      ({ cursor, hasMoreResults, pullRequests } = await this.getPullRequestsQuery(cursor));
 
-    if (release) {
-      release.prs.unshift(pr);
-    }
-  }
-
-  /**
-   * Fetch changelog.
-   */
-
-  async fetchChangelog() {
-    const [releases, prs] = await Promise.all([this.getAllReleases(), this.getAllPullRequests()]);
-
-    prs.forEach(pr => this.assignPullRequestToRelease(releases, pr));
-
-    return releases.reverse();
-  }
-
-  /**
-   * Get all pull requests.
-   */
-
-  async getAllPullRequests() {
-    const prs = await this.client.paginate(
-      this.client.pulls.list.endpoint.merge({
-        base: this.base,
-        owner: this.owner,
-        page: 1,
-        per_page: 100,
-        repo: this.repo,
-        state: 'closed'
-      })
-    );
-
-    return _(prs)
-      .filter(
-        ({ labels }) =>
-          _.isEmpty(this.labels) ||
-          !_(labels)
-            .map('name')
-            .intersection(this.labels)
-            .isEmpty()
-      )
-      .map(pr => ({ ...pr, merged_at: moment.utc(pr.merged_at) }))
-      .sortBy(pr => pr.merged_at.unix())
-      .value();
-  }
-
-  /**
-   * Get all releases.
-   */
-
-  async getAllReleases() {
-    const releases = await this.client.paginate(
-      this.client.repos.listReleases.endpoint.merge({
-        owner: this.owner,
-        page: 1,
-        per_page: 100,
-        repo: this.repo
-      })
-    );
-
-    if (this.futureRelease) {
-      releases.unshift({
-        created_at: moment().format(),
-        html_url: `https://github.com/${this.owner}/${this.repo}/releases/tag/${this.futureReleaseTag}`,
-        name: this.futureRelease
-      });
+      for (let i = 0; i < pullRequests.length; i++) {
+        // If PR was merged after the release timestamp, save it to the result.
+        if (startDate.isBefore(pullRequests[i].mergedAt)) {
+          result.push(pullRequests[i]);
+        } else if (startDate.isAfter(pullRequests[i].updatedAt)) {
+          // Stop the iteration.
+          stop = true;
+          break;
+        }
+      }
     }
 
-    return _(releases)
-      .map(release => ({ ...release, created_at: moment.utc(release.created_at), prs: [] }))
-      .sortBy(release => release.created_at.unix())
-      .value();
+    // eslint-disable-next-line id-length
+    return result.sort((a, b) => moment(b.mergedAt).diff(a.mergedAt));
+  }
+
+  /**
+   * Auxiliary function to iterage through list of releases.
+   *
+   * @param {String} cursor - the cursor from where the function will get the releases
+   * @param {Number} pageSize - the number of results we try to fetch each time
+   * @return {Map} {cursor, hasMoreResults, releases} - An array of maps with information about the last releases
+   *                                                    starting from cursor (from newest to oldest)
+   */
+  async getReleasesQuery(cursor = '', pageSize = 30) {
+    const [cursorSignature, cursorParam] = cursor ? [', $cursor: String!', ', after: $cursor'] : ['', ''];
+    const query = `
+      query getReleases($owner: String!, $repo: String!, $first: Int!${cursorSignature}) {
+        repository(owner: $owner, name: $repo) {
+          releases(first: $first, orderBy: {field: CREATED_AT, direction: DESC}${cursorParam}) {
+            nodes {
+              name
+              tagCommit {
+                committedDate
+              }
+              url
+            }
+            pageInfo {
+              endCursor
+              hasNextPage
+            }
+          }
+        }
+      }`;
+    const result = await this.client(query, {
+      cursor,
+      first: pageSize,
+      owner: this.owner,
+      repo: this.repo
+    });
+
+    return {
+      cursor: result.repository.releases.pageInfo.endCursor,
+      hasMoreResults: result.repository.releases.pageInfo.hasNextPage,
+      releases: result.repository.releases.nodes
+    };
+  }
+
+  /**
+   * Get the list of all releases of the repository.
+   *
+   * @return {Array} releases - An array of objects with information about the releases
+   */
+  async getReleases() {
+    const result = [];
+    let cursor = '';
+    let hasMoreResults = true;
+    let releases = [];
+
+    do {
+      ({ releases, cursor, hasMoreResults } = await this.getReleasesQuery(cursor));
+
+      result.push(
+        ...releases.map(({ name, tagCommit, url }) => ({
+          createdAt: moment(tagCommit.committedDate),
+          name,
+          pullRequests: [],
+          url
+        }))
+      );
+    } while (hasMoreResults);
+
+    return result;
+  }
+
+  /**
+   * Get the date that the repository was created.
+   *
+   * @return {moment} createdAt - the date the repository was created
+   */
+  async getRepositoryCreatedAt() {
+    const query = `
+      query repositoryCreation($owner: String!, $repo: String!) {
+        repository(owner: $owner, name: $repo) {
+          createdAt
+        }
+    }`;
+    const result = await this.client(query, { owner: this.owner, repo: this.repo });
+
+    return moment.utc(result.repository.createdAt);
   }
 }
 

--- a/src/changelog-formatter.js
+++ b/src/changelog-formatter.js
@@ -9,11 +9,11 @@ module.exports.formatChangelog = releases => {
 
   for (const release of releases) {
     changelog.push(
-      `\n## [${release.name || release.tag_name}](${release.html_url}) (${release.created_at.format('YYYY-MM-DD')})\n`
+      `\n## [${release.name || release.tagName}](${release.url}) (${release.createdAt.format('YYYY-MM-DD')})\n`
     );
 
-    for (const pr of release.prs) {
-      changelog.push(`- ${pr.title} [\\#${pr.number}](${pr.html_url}) ([${pr.user.login}](${pr.user.html_url}))\n`);
+    for (const { author, number, title, url } of release.pullRequests) {
+      changelog.push(`- ${title} [\\#${number}](${url}) ([${author.login}](${author.url}))\n`);
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ program
   .option('-l, --labels <names>', '[optional] labels to filter pull requests by', val => val.split(','))
   .option('-o, --owner <name>', '[optional] owner of the repository')
   .option('-r, --repo <name>', '[optional] name of the repository')
+  .option('--rebuild', 'rebuild the full changelog', false)
   .description('Run GitHub changelog generator.')
   .parse(process.argv);
 
@@ -33,7 +34,7 @@ program
  */
 
 const base = program.baseBranch || 'master';
-const { futureRelease, futureReleaseTag, labels } = program;
+const { futureRelease, futureReleaseTag, labels, rebuild } = program;
 const token = process.env.GITHUB_TOKEN;
 let { owner, repo } = program;
 
@@ -67,7 +68,7 @@ if (!owner || !repo) {
 
 async function run() {
   const fetcher = new ChangelogFetcher({ base, futureRelease, futureReleaseTag, labels, owner, repo, token });
-  const releases = await fetcher.fetchChangelog();
+  const releases = await (rebuild ? fetcher.fetchFullChangelog() : fetcher.fetchLatestChangelog());
 
   formatChangelog(releases).forEach(line => process.stdout.write(line));
 }

--- a/test/changelog-fetcher.test.js
+++ b/test/changelog-fetcher.test.js
@@ -13,6 +13,141 @@ const nock = require('nock');
  */
 
 describe('ChangelogFetcher', () => {
+  function getDataForRequest(requestBody, split = false) {
+    const { query, variables } = JSON.parse(requestBody);
+
+    if (/query latestRelease\(/.test(query)) {
+      return {
+        data: {
+          repository: {
+            latestRelease: {
+              tagCommit: {
+                committedDate: moment('2018-10-22T12').toISOString()
+              },
+              tagName: 'latestRelease'
+            }
+          }
+        }
+      };
+    } else if (/query pullRequestsBefore\(/.test(query)) {
+      const allNodes = [
+        {
+          author: { login: 'quxfoo-user-login', url: 'quxfoo-user-url' },
+          mergedAt: moment('2018-10-24T10').toISOString(),
+          number: 'quxfoo-number',
+          title: 'quxfoo-title',
+          updatedAt: moment('2018-10-24T10').toISOString(),
+          url: 'quxfoo-url'
+        },
+        {
+          author: { login: 'foobar-user-login', url: 'foobar-user-url' },
+          mergedAt: moment('2018-10-23T10').toISOString(),
+          number: 'foobar-number',
+          title: 'foobar-title',
+          updatedAt: moment('2018-10-23T10').toISOString(),
+          url: 'foobar-url'
+        },
+        {
+          author: { login: 'foobiz-user-login', url: 'foobiz-user-url' },
+          mergedAt: moment('2018-10-22T20').toISOString(),
+          number: 'foobiz-number',
+          title: 'foobiz-title',
+          updatedAt: moment('2018-10-22T20').toISOString(),
+          url: 'foobiz-url'
+        },
+        {
+          author: { login: 'barbuz-user-login', url: 'barbuz-user-url' },
+          mergedAt: moment('2018-10-21T05').toISOString(),
+          number: 'barbuz-number',
+          title: 'barbuz-title',
+          updatedAt: moment('2018-10-22T15').toISOString(),
+          url: 'barbuz-url'
+        },
+        {
+          author: { login: 'barbiz-user-login', url: 'barbiz-user-url' },
+          mergedAt: moment('2018-10-22T10').toISOString(),
+          number: 'barbiz-number',
+          title: 'barbiz-title',
+          updatedAt: moment('2018-10-22T10').toISOString(),
+          url: 'barbiz-url'
+        }
+      ];
+
+      // Return the full list of nodes if not testing cursor, else return the list in two parts.
+      // We know we should pass the second part if the cursor variable is not empty.
+      let nodes = allNodes;
+
+      if (split) {
+        nodes = variables.cursor ? allNodes.slice(2) : allNodes.slice(0, 2);
+      }
+
+      if (variables.labels.length) {
+        nodes = [allNodes[0], allNodes[2], allNodes[4]];
+      }
+
+      return {
+        data: {
+          repository: {
+            pullRequests: {
+              nodes,
+              pageInfo: {
+                endCursor: 'endCursorVal',
+                hasNextPage: split && !variables.cursor
+              }
+            }
+          }
+        }
+      };
+    } else if (/query repositoryCreation\(/.test(query)) {
+      return {
+        data: {
+          repository: {
+            createdAt: moment('2018-10-20T12').toISOString()
+          }
+        }
+      };
+    } else if (/query getReleases\(/.test(query)) {
+      const allNodes = [
+        {
+          name: 'foobar-name',
+          tagCommit: {
+            committedDate: moment('2018-10-23T12').toISOString()
+          },
+          url: 'foobar-url'
+        },
+        {
+          name: 'bizbaz-name',
+          tagCommit: {
+            committedDate: moment('2018-10-22T12').toISOString()
+          },
+          url: 'bizbaz-url'
+        }
+      ];
+
+      let nodes = allNodes;
+
+      if (split) {
+        nodes = variables.cursor ? allNodes.slice(1) : allNodes.slice(0, 1);
+      }
+
+      return {
+        data: {
+          repository: {
+            releases: {
+              nodes,
+              pageInfo: {
+                endCursor: 'endCursorVal',
+                hasNextPage: split && !variables.cursor
+              }
+            }
+          }
+        }
+      };
+    }
+
+    throw new Error('Unexpected requestBody');
+  }
+
   describe('constructor()', () => {
     it('should set all defined fields', () => {
       const fetcher = new ChangelogFetcher({
@@ -43,8 +178,8 @@ describe('ChangelogFetcher', () => {
     });
   });
 
-  describe('fetchChangelog()', () => {
-    it('should return a list of releases with their corresponding pull requests', async () => {
+  describe('fetchFullChangelog()', () => {
+    it('should return a list with all releases and the pull requests associated to them', async () => {
       const fetcher = new ChangelogFetcher({
         base: 'foo',
         owner: 'biz',
@@ -53,184 +188,58 @@ describe('ChangelogFetcher', () => {
       });
 
       nock('https://api.github.com')
-        .get('/repos/biz/buz/releases')
-        .query({ page: 1, per_page: 100 })
-        .reply(200, [
-          {
-            created_at: moment('2018-10-23T12'),
-            html_url: 'foo-url',
-            name: 'foo-name',
-            tag_name: 'foo-tag'
-          },
-          {
-            created_at: moment('2018-10-22T12'),
-            html_url: 'bar-url',
-            tag_name: 'bar-tag'
-          }
-        ]);
+        .post('/graphql')
+        .times(3)
+        .reply(200, (_, requestBody) => getDataForRequest(requestBody));
 
-      nock('https://api.github.com')
-        .get('/repos/biz/buz/pulls')
-        .query({ base: 'foo', page: 1, per_page: 100, state: 'closed' })
-        .reply(200, [
-          {
-            html_url: 'quxfoo-url',
-            merged_at: moment('2018-10-24T10'),
-            number: 'quxfoo-number',
-            title: 'quxfoo-title',
-            user: { html_url: 'quxfoo-user-url', login: 'quxfoo-user-login' }
-          },
-          {
-            html_url: 'foobar-url',
-            merged_at: moment('2018-10-23T10'),
-            number: 'foobar-number',
-            title: 'foobar-title',
-            user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
-          },
-          {
-            html_url: 'foobiz-url',
-            merged_at: moment('2018-10-22T20'),
-            number: 'foobiz-number',
-            title: 'foobiz-title',
-            user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
-          },
-          {
-            html_url: 'barbiz-url',
-            merged_at: moment('2018-10-22T10'),
-            number: 'barbiz-number',
-            title: 'barbiz-title',
-            user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
-          },
-          {
-            html_url: 'barbuz-url',
-            merged_at: moment('2018-10-21T05'),
-            number: 'barbuz-number',
-            title: 'barbuz-title',
-            user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
-          }
-        ]);
-
-      const releases = await fetcher.fetchChangelog();
+      const releases = await fetcher.fetchFullChangelog();
 
       expect(releases).toEqual([
         {
-          created_at: expect.any(moment),
-          html_url: 'foo-url',
-          name: 'foo-name',
-          prs: [
+          createdAt: moment(moment('2018-10-23T12').toISOString()),
+          name: 'foobar-name',
+          pullRequests: [
             {
-              html_url: 'foobar-url',
-              merged_at: expect.any(moment),
+              author: { login: 'foobar-user-login', url: 'foobar-user-url' },
+              mergedAt: moment('2018-10-23T10').toISOString(),
               number: 'foobar-number',
               title: 'foobar-title',
-              user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
+              updatedAt: moment('2018-10-23T10').toISOString(),
+              url: 'foobar-url'
             },
             {
-              html_url: 'foobiz-url',
-              merged_at: expect.any(moment),
+              author: { login: 'foobiz-user-login', url: 'foobiz-user-url' },
+              mergedAt: moment('2018-10-22T20').toISOString(),
               number: 'foobiz-number',
               title: 'foobiz-title',
-              user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
+              updatedAt: moment('2018-10-22T20').toISOString(),
+              url: 'foobiz-url'
             }
           ],
-          tag_name: 'foo-tag'
+          url: 'foobar-url'
         },
         {
-          created_at: expect.any(moment),
-          html_url: 'bar-url',
-          prs: [
+          createdAt: moment(moment('2018-10-22T12').toISOString()),
+          name: 'bizbaz-name',
+          pullRequests: [
             {
-              html_url: 'barbiz-url',
-              merged_at: expect.any(moment),
+              author: { login: 'barbiz-user-login', url: 'barbiz-user-url' },
+              mergedAt: moment('2018-10-22T10').toISOString(),
               number: 'barbiz-number',
               title: 'barbiz-title',
-              user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
+              updatedAt: moment('2018-10-22T10').toISOString(),
+              url: 'barbiz-url'
             },
             {
-              html_url: 'barbuz-url',
-              merged_at: expect.any(moment),
+              author: { login: 'barbuz-user-login', url: 'barbuz-user-url' },
+              mergedAt: moment('2018-10-21T05').toISOString(),
               number: 'barbuz-number',
               title: 'barbuz-title',
-              user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
+              updatedAt: moment('2018-10-22T15').toISOString(),
+              url: 'barbuz-url'
             }
           ],
-          tag_name: 'bar-tag'
-        }
-      ]);
-    });
-
-    it('should add a new release based on `futureRelease`', async () => {
-      const fetcher = new ChangelogFetcher({
-        base: 'foo',
-        futureRelease: 'bar',
-        owner: 'biz',
-        repo: 'buz',
-        token: 'qux'
-      });
-
-      nock('https://api.github.com')
-        .get('/repos/biz/buz/releases')
-        .query({ page: 1, per_page: 100 })
-        .reply(200, [
-          {
-            created_at: moment('2018-10-23T12'),
-            html_url: 'foo-url',
-            name: 'foo-name',
-            tag_name: 'foo-tag'
-          }
-        ]);
-
-      nock('https://api.github.com')
-        .get('/repos/biz/buz/pulls')
-        .query({ base: 'foo', page: 1, per_page: 100, state: 'closed' })
-        .reply(200, [
-          {
-            html_url: 'foobar-url',
-            merged_at: moment('2018-10-23T16'),
-            number: 'foobar-number',
-            title: 'foobar-title',
-            user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
-          },
-          {
-            html_url: 'foobiz-url',
-            merged_at: moment('2018-10-22T20'),
-            number: 'foobiz-number',
-            title: 'foobiz-title',
-            user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
-          }
-        ]);
-
-      const releases = await fetcher.fetchChangelog();
-
-      expect(releases).toEqual([
-        {
-          created_at: expect.any(moment),
-          html_url: 'https://github.com/biz/buz/releases/tag/bar',
-          name: 'bar',
-          prs: [
-            {
-              html_url: 'foobar-url',
-              merged_at: expect.any(moment),
-              number: 'foobar-number',
-              title: 'foobar-title',
-              user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
-            }
-          ]
-        },
-        {
-          created_at: expect.any(moment),
-          html_url: 'foo-url',
-          name: 'foo-name',
-          prs: [
-            {
-              html_url: 'foobiz-url',
-              merged_at: expect.any(moment),
-              number: 'foobiz-number',
-              title: 'foobiz-title',
-              user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
-            }
-          ],
-          tag_name: 'foo-tag'
+          url: 'bizbaz-url'
         }
       ]);
     });
@@ -244,141 +253,58 @@ describe('ChangelogFetcher', () => {
       });
 
       nock('https://api.github.com')
-        .get('/repos/biz/buz/releases')
-        .query({ page: 1, per_page: 100 })
-        .reply(
-          200,
-          [
-            {
-              created_at: moment('2018-10-23T12'),
-              html_url: 'foo-url',
-              name: 'foo-name',
-              tag_name: 'foo-tag'
-            }
-          ],
-          {
-            link:
-              '<https://api.github.com/repos/biz/buz/releases?page=2&per_page=100>; rel="next", <https://api.github.com/repos/biz/buz/releases?page=2&per_page=1000>; rel="last"'
-          }
-        );
+        .post('/graphql')
+        .times(5)
+        .reply(200, (_, requestBody) => getDataForRequest(requestBody, true));
 
-      nock('https://api.github.com')
-        .get('/repos/biz/buz/releases')
-        .query({ page: 2, per_page: 100 })
-        .reply(
-          200,
-          [
-            {
-              created_at: moment('2018-10-22T12'),
-              html_url: 'bar-url',
-              tag_name: 'bar-tag'
-            }
-          ],
-          {
-            link:
-              '<https://api.github.com/repos/biz/buz/releases&page=1&per_page=100>; rel="prev"; <https://api.github.com/repos/biz/buz/releases&page=1&per_page=100>; rel="first";'
-          }
-        );
-
-      nock('https://api.github.com')
-        .get('/repos/biz/buz/pulls')
-        .query({ base: 'foo', page: 1, per_page: 100, state: 'closed' })
-        .reply(
-          200,
-          [
-            {
-              html_url: 'foobar-url',
-              merged_at: moment('2018-10-23T10'),
-              number: 'foobar-number',
-              title: 'foobar-title',
-              user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
-            },
-            {
-              html_url: 'foobiz-url',
-              merged_at: moment('2018-10-22T20'),
-              number: 'foobiz-number',
-              title: 'foobiz-title',
-              user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
-            },
-            {
-              html_url: 'barbiz-url',
-              merged_at: moment('2018-10-22T10'),
-              number: 'barbiz-number',
-              title: 'barbiz-title',
-              user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
-            }
-          ],
-          {
-            link:
-              '<https://api.github.com/repos/biz/buz/pulls?page=2&per_page=100&base=foo&state=closed>; rel="next", <https://api.github.com/repos/biz/buz/pulls?page=2&per_page=100&base=foo&state=closed>; rel="last"'
-          }
-        );
-
-      nock('https://api.github.com')
-        .get('/repos/biz/buz/pulls')
-        .query({ base: 'foo', page: 2, per_page: 100, state: 'closed' })
-        .reply(
-          200,
-          [
-            {
-              html_url: 'barbuz-url',
-              merged_at: moment('2018-10-21T05'),
-              number: 'barbuz-number',
-              title: 'barbuz-title',
-              user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
-            }
-          ],
-          {
-            link:
-              '<https://api.github.com/repos/biz/buz/pulls&page=1&per_page=100&base=foo&state=closed>; rel="prev"; <https://api.github.com/repos/biz/buz/pulls&page=1&per_page=100&base=foo&state=closed>; rel="first";'
-          }
-        );
-
-      const releases = await fetcher.fetchChangelog();
+      const releases = await fetcher.fetchFullChangelog();
 
       expect(releases).toEqual([
         {
-          created_at: expect.any(moment),
-          html_url: 'foo-url',
-          name: 'foo-name',
-          prs: [
+          createdAt: moment(moment('2018-10-23T12').toISOString()),
+          name: 'foobar-name',
+          pullRequests: [
             {
-              html_url: 'foobar-url',
-              merged_at: expect.any(moment),
+              author: { login: 'foobar-user-login', url: 'foobar-user-url' },
+              mergedAt: moment('2018-10-23T10').toISOString(),
               number: 'foobar-number',
               title: 'foobar-title',
-              user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
+              updatedAt: moment('2018-10-23T10').toISOString(),
+              url: 'foobar-url'
             },
             {
-              html_url: 'foobiz-url',
-              merged_at: expect.any(moment),
+              author: { login: 'foobiz-user-login', url: 'foobiz-user-url' },
+              mergedAt: moment('2018-10-22T20').toISOString(),
               number: 'foobiz-number',
               title: 'foobiz-title',
-              user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
+              updatedAt: moment('2018-10-22T20').toISOString(),
+              url: 'foobiz-url'
             }
           ],
-          tag_name: 'foo-tag'
+          url: 'foobar-url'
         },
         {
-          created_at: expect.any(moment),
-          html_url: 'bar-url',
-          prs: [
+          createdAt: moment(moment('2018-10-22T12').toISOString()),
+          name: 'bizbaz-name',
+          pullRequests: [
             {
-              html_url: 'barbiz-url',
-              merged_at: expect.any(moment),
+              author: { login: 'barbiz-user-login', url: 'barbiz-user-url' },
+              mergedAt: moment('2018-10-22T10').toISOString(),
               number: 'barbiz-number',
               title: 'barbiz-title',
-              user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
+              updatedAt: moment('2018-10-22T10').toISOString(),
+              url: 'barbiz-url'
             },
             {
-              html_url: 'barbuz-url',
-              merged_at: expect.any(moment),
+              author: { login: 'barbuz-user-login', url: 'barbuz-user-url' },
+              mergedAt: moment('2018-10-21T05').toISOString(),
               number: 'barbuz-number',
               title: 'barbuz-title',
-              user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
+              updatedAt: moment('2018-10-22T15').toISOString(),
+              url: 'barbuz-url'
             }
           ],
-          tag_name: 'bar-tag'
+          url: 'bizbaz-url'
         }
       ]);
     });
@@ -386,6 +312,7 @@ describe('ChangelogFetcher', () => {
     it('should filter pull requests by the given list of labels', async () => {
       const fetcher = new ChangelogFetcher({
         base: 'foo',
+        futureRelease: 'futRel',
         labels: ['fizz', 'fuzz'],
         owner: 'biz',
         repo: 'buz',
@@ -393,107 +320,376 @@ describe('ChangelogFetcher', () => {
       });
 
       nock('https://api.github.com')
-        .get('/repos/biz/buz/releases')
-        .query({ page: 1, per_page: 100 })
-        .reply(200, [
-          {
-            created_at: moment('2018-10-23T12'),
-            html_url: 'foo-url',
-            name: 'foo-name',
-            tag_name: 'foo-tag'
-          }
-        ]);
+        .post('/graphql')
+        .times(3)
+        .reply(200, (_, requestBody) => getDataForRequest(requestBody));
 
-      nock('https://api.github.com')
-        .get('/repos/biz/buz/pulls')
-        .query({ base: 'foo', page: 1, per_page: 100, state: 'closed' })
-        .reply(200, [
-          {
-            html_url: 'quxfoo-url',
-            labels: [{ name: 'fizz' }],
-            merged_at: moment('2018-10-23T10'),
-            number: 'quxfoo-number',
-            title: 'quxfoo-title',
-            user: { html_url: 'quxfoo-user-url', login: 'quxfoo-user-login' }
-          },
-          {
-            html_url: 'foobar-url',
-            labels: [{ name: 'bar' }],
-            merged_at: moment('2018-10-22T10'),
-            number: 'foobar-number',
-            title: 'foobar-title',
-            user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
-          },
-          {
-            html_url: 'foobiz-url',
-            labels: [{ name: 'fuzz' }],
-            merged_at: moment('2018-10-21T20'),
-            number: 'foobiz-number',
-            title: 'foobiz-title',
-            user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
-          },
-          {
-            html_url: 'barbiz-url',
-            labels: [{ name: 'fizz' }, { name: 'bar' }],
-            merged_at: moment('2018-10-20T10'),
-            number: 'barbiz-number',
-            title: 'barbiz-title',
-            user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
-          },
-          {
-            html_url: 'barbuz-url',
-            labels: [{ name: 'bar' }, { name: 'baz' }],
-            merged_at: moment('2018-10-19T10'),
-            number: 'barbuz-number',
-            title: 'barbuz-title',
-            user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
-          },
-          {
-            html_url: 'foobuz-url',
-            labels: [],
-            merged_at: moment('2018-10-19T10'),
-            number: 'foobuz-number',
-            title: 'foobuz-title',
-            user: { html_url: 'foobuz-user-url', login: 'foobuz-user-login' }
-          }
-        ]);
-
-      const releases = await fetcher.fetchChangelog();
+      const releases = await fetcher.fetchFullChangelog();
 
       expect(releases).toEqual([
         {
-          created_at: expect.any(moment),
-          html_url: 'foo-url',
-          name: 'foo-name',
-          prs: [
+          createdAt: moment(moment('2018-10-23T12').toISOString()),
+          name: 'foobar-name',
+          pullRequests: [
             {
-              html_url: 'quxfoo-url',
-              labels: [{ name: 'fizz' }],
-              merged_at: expect.any(moment),
-              number: 'quxfoo-number',
-              title: 'quxfoo-title',
-              user: { html_url: 'quxfoo-user-url', login: 'quxfoo-user-login' }
-            },
-            {
-              html_url: 'foobiz-url',
-              labels: [{ name: 'fuzz' }],
-              merged_at: expect.any(moment),
+              author: { login: 'foobiz-user-login', url: 'foobiz-user-url' },
+              mergedAt: moment('2018-10-22T20').toISOString(),
               number: 'foobiz-number',
               title: 'foobiz-title',
-              user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
-            },
-            {
-              html_url: 'barbiz-url',
-              labels: [{ name: 'fizz' }, { name: 'bar' }],
-              merged_at: expect.any(moment),
-              number: 'barbiz-number',
-              title: 'barbiz-title',
-              user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
+              updatedAt: moment('2018-10-22T20').toISOString(),
+              url: 'foobiz-url'
             }
           ],
-          tag_name: 'foo-tag'
+          url: 'foobar-url'
+        },
+        {
+          createdAt: moment(moment('2018-10-22T12').toISOString()),
+          name: 'bizbaz-name',
+          pullRequests: [
+            {
+              author: { login: 'barbiz-user-login', url: 'barbiz-user-url' },
+              mergedAt: moment('2018-10-22T10').toISOString(),
+              number: 'barbiz-number',
+              title: 'barbiz-title',
+              updatedAt: moment('2018-10-22T10').toISOString(),
+              url: 'barbiz-url'
+            }
+          ],
+          url: 'bizbaz-url'
         }
       ]);
+    });
+  });
+
+  describe('fetchLatestChangelog()', () => {
+    it('should not return any releases unless you specify a futureRelease', async () => {
+      const fetcher = new ChangelogFetcher({
+        base: 'foo',
+        owner: 'biz',
+        repo: 'buz',
+        token: 'qux'
+      });
+      const releases = await fetcher.fetchLatestChangelog();
+
+      expect(releases).toEqual([]);
+    });
+
+    it('should throw an error if the futureReleaseTag is already the latest realease', async () => {
+      const fetcher = new ChangelogFetcher({
+        base: 'foo',
+        futureRelease: 'bar',
+        owner: 'biz',
+        repo: 'buz',
+        token: 'qux'
+      });
+
+      jest.spyOn(fetcher, 'client').mockReturnValue({
+        repository: {
+          latestRelease: {
+            tagCommit: {
+              committedDate: moment('2018-10-22T12').toISOString()
+            },
+            tagName: 'bar'
+          }
+        }
+      });
+
+      try {
+        await fetcher.fetchLatestChangelog();
+
+        jest.fail();
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toBe('Changelog already on the latest release');
+      }
+    });
+
+    it('should return a list with the last release and the pull requests done after the last release was created', async () => {
+      const fetcher = new ChangelogFetcher({
+        base: 'foo',
+        futureRelease: 'futRel',
+        owner: 'biz',
+        repo: 'buz',
+        token: 'qux'
+      });
+
+      nock('https://api.github.com')
+        .post('/graphql')
+        .times(2)
+        .reply(200, (_, requestBody) => getDataForRequest(requestBody));
+
+      const releases = await fetcher.fetchLatestChangelog();
+
+      expect(releases).toEqual([
+        {
+          createdAt: expect.any(moment),
+          name: 'futRel',
+          pullRequests: [
+            {
+              author: { login: 'quxfoo-user-login', url: 'quxfoo-user-url' },
+              mergedAt: moment('2018-10-24T10').toISOString(),
+              number: 'quxfoo-number',
+              title: 'quxfoo-title',
+              updatedAt: moment('2018-10-24T10').toISOString(),
+              url: 'quxfoo-url'
+            },
+            {
+              author: { login: 'foobar-user-login', url: 'foobar-user-url' },
+              mergedAt: moment('2018-10-23T10').toISOString(),
+              number: 'foobar-number',
+              title: 'foobar-title',
+              updatedAt: moment('2018-10-23T10').toISOString(),
+              url: 'foobar-url'
+            },
+            {
+              author: { login: 'foobiz-user-login', url: 'foobiz-user-url' },
+              mergedAt: moment('2018-10-22T20').toISOString(),
+              number: 'foobiz-number',
+              title: 'foobiz-title',
+              updatedAt: moment('2018-10-22T20').toISOString(),
+              url: 'foobiz-url'
+            }
+          ],
+          url: 'https://github.com/biz/buz/releases/tag/futRel'
+        }
+      ]);
+    });
+
+    it('should handle pagination correctly', async () => {
+      const fetcher = new ChangelogFetcher({
+        base: 'foo',
+        futureRelease: 'futRel',
+        owner: 'biz',
+        repo: 'buz',
+        token: 'qux'
+      });
+
+      nock('https://api.github.com')
+        .post('/graphql')
+        .times(3)
+        .reply(200, (_, requestBody) => getDataForRequest(requestBody, true));
+
+      const releases = await fetcher.fetchLatestChangelog();
+
+      expect(releases).toEqual([
+        {
+          createdAt: expect.any(moment),
+          name: 'futRel',
+          pullRequests: [
+            {
+              author: { login: 'quxfoo-user-login', url: 'quxfoo-user-url' },
+              mergedAt: moment('2018-10-24T10').toISOString(),
+              number: 'quxfoo-number',
+              title: 'quxfoo-title',
+              updatedAt: moment('2018-10-24T10').toISOString(),
+              url: 'quxfoo-url'
+            },
+            {
+              author: { login: 'foobar-user-login', url: 'foobar-user-url' },
+              mergedAt: moment('2018-10-23T10').toISOString(),
+              number: 'foobar-number',
+              title: 'foobar-title',
+              updatedAt: moment('2018-10-23T10').toISOString(),
+              url: 'foobar-url'
+            },
+            {
+              author: { login: 'foobiz-user-login', url: 'foobiz-user-url' },
+              mergedAt: moment('2018-10-22T20').toISOString(),
+              number: 'foobiz-number',
+              title: 'foobiz-title',
+              updatedAt: moment('2018-10-22T20').toISOString(),
+              url: 'foobiz-url'
+            }
+          ],
+          url: 'https://github.com/biz/buz/releases/tag/futRel'
+        }
+      ]);
+    });
+
+    it('should filter pull requests by the given list of labels', async () => {
+      const fetcher = new ChangelogFetcher({
+        base: 'foo',
+        futureRelease: 'futRel',
+        labels: ['fizz', 'fuzz'],
+        owner: 'biz',
+        repo: 'buz',
+        token: 'qux'
+      });
+
+      nock('https://api.github.com')
+        .post('/graphql')
+        .times(2)
+        .reply(200, (_, requestBody) => getDataForRequest(requestBody));
+
+      const releases = await fetcher.fetchLatestChangelog();
+
+      expect(releases).toEqual([
+        {
+          createdAt: expect.any(moment),
+          name: 'futRel',
+          pullRequests: [
+            {
+              author: { login: 'quxfoo-user-login', url: 'quxfoo-user-url' },
+              mergedAt: moment('2018-10-24T10').toISOString(),
+              number: 'quxfoo-number',
+              title: 'quxfoo-title',
+              updatedAt: moment('2018-10-24T10').toISOString(),
+              url: 'quxfoo-url'
+            },
+            {
+              author: { login: 'foobiz-user-login', url: 'foobiz-user-url' },
+              mergedAt: moment('2018-10-22T20').toISOString(),
+              number: 'foobiz-number',
+              title: 'foobiz-title',
+              updatedAt: moment('2018-10-22T20').toISOString(),
+              url: 'foobiz-url'
+            }
+          ],
+          url: 'https://github.com/biz/buz/releases/tag/futRel'
+        }
+      ]);
+    });
+
+    it('should stop iterating when a pull request has an updated at that is before the start timestamp', async () => {
+      const fetcher = new ChangelogFetcher({
+        base: 'foo',
+        futureRelease: 'futRel',
+        owner: 'biz',
+        repo: 'buz',
+        token: 'qux'
+      });
+      const startDate = moment('2018-10-23T08');
+
+      nock('https://api.github.com')
+        .post('/graphql')
+        .times(1)
+        .reply(200, (_, requestBody) => getDataForRequest(requestBody));
+
+      jest.spyOn(fetcher, 'getLatestRelease').mockReturnValue({ tagCommit: { committedDate: startDate } });
+      jest.spyOn(startDate, 'isAfter');
+      jest.spyOn(startDate, 'isBefore');
+
+      const releases = await fetcher.fetchLatestChangelog();
+
+      expect(releases[0].pullRequests).toHaveLength(2);
+      expect(startDate.isAfter).toHaveBeenCalledTimes(1);
+      expect(startDate.isAfter).toHaveReturnedWith(true);
+      expect(startDate.isBefore).toHaveBeenCalledTimes(3);
+      expect(startDate.isBefore).toHaveNthReturnedWith(1, true);
+      expect(startDate.isBefore).toHaveNthReturnedWith(2, true);
+      expect(startDate.isBefore).toHaveNthReturnedWith(3, false);
+    });
+
+    it('should stop iterating when no more pull requests exist', async () => {
+      const fetcher = new ChangelogFetcher({
+        base: 'foo',
+        futureRelease: 'futRel',
+        owner: 'biz',
+        repo: 'buz',
+        token: 'qux'
+      });
+      const startDate = moment('2018-10-10T08');
+
+      nock('https://api.github.com')
+        .post('/graphql')
+        .times(1)
+        .reply(200, (_, requestBody) => getDataForRequest(requestBody));
+
+      jest.spyOn(fetcher, 'getLatestRelease').mockReturnValue({ tagCommit: { committedDate: startDate } });
+      jest.spyOn(startDate, 'isAfter');
+      jest.spyOn(startDate, 'isBefore');
+
+      const releases = await fetcher.fetchLatestChangelog();
+
+      expect(releases[0].pullRequests).toHaveLength(5);
+      expect(startDate.isAfter).not.toHaveBeenCalled();
+      expect(startDate.isBefore).toHaveBeenCalledTimes(5);
+      expect(startDate.isBefore).toHaveNthReturnedWith(1, true);
+      expect(startDate.isBefore).toHaveNthReturnedWith(2, true);
+      expect(startDate.isBefore).toHaveNthReturnedWith(3, true);
+      expect(startDate.isBefore).toHaveNthReturnedWith(4, true);
+      expect(startDate.isBefore).toHaveNthReturnedWith(5, true);
+    });
+  });
+
+  describe('getLatestRelease()', () => {
+    it('should query the client', async () => {
+      const fetcher = new ChangelogFetcher({
+        owner: 'biz',
+        repo: 'buz',
+        token: 'qux'
+      });
+
+      jest.spyOn(fetcher, 'client').mockReturnValue({
+        repository: { latestRelease: { tagCommit: { committedDate: moment('2020-01-01').toISOString() } } }
+      });
+
+      await fetcher.getLatestRelease();
+
+      expect(fetcher.client).toHaveBeenCalledTimes(1);
+      expect(fetcher.client).toHaveBeenCalledWith(expect.any(String), {
+        owner: fetcher.owner,
+        repo: fetcher.repo
+      });
+    });
+
+    it('should return the latest release', async () => {
+      const fetcher = new ChangelogFetcher({
+        owner: 'biz',
+        repo: 'buz',
+        token: 'qux'
+      });
+
+      nock('https://api.github.com')
+        .post('/graphql')
+        .reply(200, (_, requestBody) => getDataForRequest(requestBody));
+
+      const result = await fetcher.getLatestRelease();
+
+      expect(result).toEqual({
+        tagCommit: {
+          committedDate: moment.utc(moment('2018-10-22T12').toISOString())
+        },
+        tagName: 'latestRelease'
+      });
+    });
+  });
+
+  describe('getRepositoryCreatedAt()', () => {
+    it('should query the client', async () => {
+      const fetcher = new ChangelogFetcher({
+        owner: 'biz',
+        repo: 'buz',
+        token: 'qux'
+      });
+
+      jest.spyOn(fetcher, 'client').mockReturnValue({
+        repository: { createdAt: moment('2020-01-01').toISOString() }
+      });
+
+      await fetcher.getRepositoryCreatedAt();
+
+      expect(fetcher.client).toHaveBeenCalledTimes(1);
+      expect(fetcher.client).toHaveBeenCalledWith(expect.any(String), {
+        owner: fetcher.owner,
+        repo: fetcher.repo
+      });
+    });
+
+    it('should return the date the repository was created', async () => {
+      const fetcher = new ChangelogFetcher({
+        owner: 'biz',
+        repo: 'buz',
+        token: 'qux'
+      });
+
+      nock('https://api.github.com')
+        .post('/graphql')
+        .reply(200, (_, requestBody) => getDataForRequest(requestBody));
+
+      const result = await fetcher.getRepositoryCreatedAt();
+
+      expect(result).toEqual(moment.utc(moment('2018-10-20T12').toISOString()));
     });
   });
 });

--- a/test/changelog-formatter.test.js
+++ b/test/changelog-formatter.test.js
@@ -16,43 +16,43 @@ describe('ChangelogFormatter', () => {
     it('should return an array of lines for releases and pull requests in the expected format', () => {
       const releases = [
         {
-          created_at: moment('2018-10-23'),
-          html_url: 'foo-url',
+          createdAt: moment('2018-10-23'),
           name: 'foo-name',
-          prs: [
+          pullRequests: [
             {
-              html_url: 'foobar-url',
+              author: { login: 'foobar-user-login', url: 'foobar-user-url' },
               number: 'foobar-number',
               title: 'foobar-title',
-              user: { html_url: 'foobar-user-url', login: 'foobar-user-login' }
+              url: 'foobar-url'
             },
             {
-              html_url: 'foobiz-url',
+              author: { login: 'foobiz-user-login', url: 'foobiz-user-url' },
               number: 'foobiz-number',
               title: 'foobiz-title',
-              user: { html_url: 'foobiz-user-url', login: 'foobiz-user-login' }
+              url: 'foobiz-url'
             }
           ],
-          tag_name: 'foo-tag'
+          tagName: 'foo-tag',
+          url: 'foo-url'
         },
         {
-          created_at: moment('2018-10-22'),
-          html_url: 'bar-url',
-          prs: [
+          createdAt: moment('2018-10-22'),
+          pullRequests: [
             {
-              html_url: 'barbiz-url',
+              author: { login: 'barbiz-user-login', url: 'barbiz-user-url' },
               number: 'barbiz-number',
               title: 'barbiz-title',
-              user: { html_url: 'barbiz-user-url', login: 'barbiz-user-login' }
+              url: 'barbiz-url'
             },
             {
-              html_url: 'barbuz-url',
+              author: { login: 'barbuz-user-login', url: 'barbuz-user-url' },
               number: 'barbuz-number',
               title: 'barbuz-title',
-              user: { html_url: 'barbuz-user-url', login: 'barbuz-user-login' }
+              url: 'barbuz-url'
             }
           ],
-          tag_name: 'bar-tag'
+          tagName: 'bar-tag',
+          url: 'bar-url'
         }
       ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
-  dependencies:
-    "@babel/highlight" "^7.0.0"
-
-"@babel/code-frame@^7.5.5":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
   integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
@@ -34,16 +28,6 @@
     resolve "^1.3.2"
     semver "^5.4.1"
     source-map "^0.5.0"
-
-"@babel/generator@^7.1.3":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.1.3.tgz#2103ec9c42d9bdad9190a6ad5ff2d456fd7b8673"
-  dependencies:
-    "@babel/types" "^7.1.3"
-    jsesc "^2.5.1"
-    lodash "^4.17.10"
-    source-map "^0.5.0"
-    trim-right "^1.0.1"
 
 "@babel/generator@^7.4.0", "@babel/generator@^7.6.3", "@babel/generator@^7.6.4":
   version "7.6.4"
@@ -74,12 +58,6 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
   integrity sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==
 
-"@babel/helper-split-export-declaration@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz#3aae285c0311c2ab095d997b8c9a94cad547d813"
-  dependencies:
-    "@babel/types" "^7.0.0"
-
 "@babel/helper-split-export-declaration@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
@@ -104,11 +82,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.2", "@babel/parser@^7.1.3":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.3.tgz#2c92469bac2b7fbff810b67fca07bd138b48af77"
-
-"@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.6.0", "@babel/parser@^7.6.3", "@babel/parser@^7.6.4":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.6.0", "@babel/parser@^7.6.3", "@babel/parser@^7.6.4":
   version "7.6.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.4.tgz#cb9b36a7482110282d5cb6dd424ec9262b473d81"
   integrity sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==
@@ -120,15 +94,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/template@^7.1.0":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.2.tgz#090484a574fef5a2d2d7726a674eceda5c5b5644"
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.1.2"
-    "@babel/types" "^7.1.2"
-
-"@babel/template@^7.4.0", "@babel/template@^7.6.0":
+"@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.6.0.tgz#7f0159c7f5012230dad64cca42ec9bdb5c9536e6"
   integrity sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==
@@ -137,21 +103,7 @@
     "@babel/parser" "^7.6.0"
     "@babel/types" "^7.6.0"
 
-"@babel/traverse@^7.0.0":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.1.4.tgz#f4f83b93d649b4b2c91121a9087fa2fa949ec2b4"
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.1.3"
-    "@babel/helper-function-name" "^7.1.0"
-    "@babel/helper-split-export-declaration" "^7.0.0"
-    "@babel/parser" "^7.1.3"
-    "@babel/types" "^7.1.3"
-    debug "^3.1.0"
-    globals "^11.1.0"
-    lodash "^4.17.10"
-
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.6.2", "@babel/traverse@^7.6.3":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.6.2", "@babel/traverse@^7.6.3":
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.3.tgz#66d7dba146b086703c0fb10dd588b7364cec47f9"
   integrity sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==
@@ -166,15 +118,7 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.1.3":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.1.3.tgz#3a767004567060c2f40fca49a304712c525ee37d"
-  dependencies:
-    esutils "^2.0.2"
-    lodash "^4.17.10"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.6.0", "@babel/types@^7.6.3":
+"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.6.0", "@babel/types@^7.6.3":
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.3.tgz#3f07d96f854f98e2fbd45c64b0cb942d11e8ba09"
   integrity sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==
@@ -339,62 +283,65 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@octokit/endpoint@^5.5.0":
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-5.5.1.tgz#2eea81e110ca754ff2de11c79154ccab4ae16b3f"
-  integrity sha512-nBFhRUb5YzVTCX/iAK1MgQ4uWo89Gu0TH00qQHoYRCsE12dWcG1OiLd7v2EIo2+tpUKPMOQ62QFy9hy9Vg2ULg==
+"@octokit/endpoint@^6.0.1":
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.5.tgz#43a6adee813c5ffd2f719e20cfd14a1fee7c193a"
+  integrity sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==
   dependencies:
-    "@octokit/types" "^2.0.0"
-    is-plain-object "^3.0.0"
-    universal-user-agent "^4.0.0"
+    "@octokit/types" "^5.0.0"
+    is-plain-object "^4.0.0"
+    universal-user-agent "^6.0.0"
 
-"@octokit/request-error@^1.0.1", "@octokit/request-error@^1.0.2":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-1.2.0.tgz#a64d2a9d7a13555570cd79722de4a4d76371baaa"
-  integrity sha512-DNBhROBYjjV/I9n7A8kVkmQNkqFAMem90dSxqvPq57e2hBr7mNTX98y3R2zDpqMQHVRpBDjsvsfIGgBzy+4PAg==
+"@octokit/graphql@^4.6.1":
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.6.1.tgz#f975486a46c94b7dbe58a0ca751935edc7e32cc9"
+  integrity sha512-2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==
   dependencies:
-    "@octokit/types" "^2.0.0"
+    "@octokit/request" "^5.3.0"
+    "@octokit/types" "^6.0.3"
+    universal-user-agent "^6.0.0"
+
+"@octokit/openapi-types@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-6.0.0.tgz#7da8d7d5a72d3282c1a3ff9f951c8133a707480d"
+  integrity sha512-CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ==
+
+"@octokit/request-error@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.0.2.tgz#0e76b83f5d8fdda1db99027ea5f617c2e6ba9ed0"
+  integrity sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==
+  dependencies:
+    "@octokit/types" "^5.0.1"
     deprecation "^2.0.0"
     once "^1.4.0"
 
-"@octokit/request@^5.2.0":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.3.1.tgz#3a1ace45e6f88b1be4749c5da963b3a3b4a2f120"
-  integrity sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==
+"@octokit/request@^5.3.0":
+  version "5.4.7"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.7.tgz#fd703ee092e0463ceba49ff7a3e61cb4cf8a0fde"
+  integrity sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==
   dependencies:
-    "@octokit/endpoint" "^5.5.0"
-    "@octokit/request-error" "^1.0.1"
-    "@octokit/types" "^2.0.0"
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.0.0"
+    "@octokit/types" "^5.0.0"
     deprecation "^2.0.0"
-    is-plain-object "^3.0.0"
+    is-plain-object "^4.0.0"
     node-fetch "^2.3.0"
     once "^1.4.0"
-    universal-user-agent "^4.0.0"
+    universal-user-agent "^6.0.0"
 
-"@octokit/rest@^16.34.1":
-  version "16.34.1"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.34.1.tgz#e28b5a573ca2f15bb002f90bc010020845ed9c01"
-  integrity sha512-JUoS12cdktf1fv86rgrjC/RvYLuL+o7p57W7zX1x7ANFJ7OvdV8emvUNkFlcidEaOkYrxK3SoWgQFt3FhNmabA==
-  dependencies:
-    "@octokit/request" "^5.2.0"
-    "@octokit/request-error" "^1.0.2"
-    atob-lite "^2.0.0"
-    before-after-hook "^2.0.0"
-    btoa-lite "^1.0.0"
-    deprecation "^2.0.0"
-    lodash.get "^4.4.2"
-    lodash.set "^4.3.2"
-    lodash.uniq "^4.5.0"
-    octokit-pagination-methods "^1.1.0"
-    once "^1.4.0"
-    universal-user-agent "^4.0.0"
-
-"@octokit/types@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.0.1.tgz#0caf0364e010296265621593ac9a37f40ef75dad"
-  integrity sha512-YDYgV6nCzdGdOm7wy43Ce8SQ3M5DMKegB8E5sTB/1xrxOdo2yS/KgUgML2N2ZGD621mkbdrAglwTyA4NDOlFFA==
+"@octokit/types@^5.0.0", "@octokit/types@^5.0.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.4.1.tgz#d5d5f2b70ffc0e3f89467c3db749fa87fc3b7031"
+  integrity sha512-OlMlSySBJoJ6uozkr/i03nO5dlYQyE05vmQNZhAh9MyO4DPBP88QlwsDVLmVjIMFssvIZB6WO0ctIGMRG+xsJQ==
   dependencies:
     "@types/node" ">= 8"
+
+"@octokit/types@^6.0.3":
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.13.0.tgz#779e5b7566c8dde68f2f6273861dd2f0409480d0"
+  integrity sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==
+  dependencies:
+    "@octokit/openapi-types" "^6.0.0"
 
 "@types/babel__core@^7.1.0":
   version "7.1.3"
@@ -527,11 +474,7 @@ ajv@^6.10.0, ajv@^6.10.2:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ansi-escapes@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
-
-ansi-escapes@^3.2.0:
+ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
@@ -627,11 +570,6 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-atob-lite@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/atob-lite/-/atob-lite-2.0.0.tgz#0fef5ad46f1bd7a8502c65727f0367d5ee43d696"
-  integrity sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=
-
 atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -717,11 +655,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-before-after-hook@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
-  integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -760,17 +693,9 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-btoa-lite@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
-
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
-
-buffer-shims@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -823,15 +748,7 @@ chai@^4.1.2:
     pathval "^1.1.0"
     type-detect "^4.0.5"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
-chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1007,19 +924,7 @@ debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.0.1, debug@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.1.1:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -1233,11 +1138,7 @@ eslint-utils@^1.4.2:
   dependencies:
     eslint-visitor-keys "^1.0.0"
 
-eslint-visitor-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
-
-eslint-visitor-keys@^1.1.0:
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
@@ -1585,29 +1486,7 @@ glob-parent@^5.0.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.0.5:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.1, glob@^7.1.2:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.3:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
@@ -1623,11 +1502,7 @@ globals@^11.1.0, globals@^11.7.0:
   version "11.8.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.8.0.tgz#c1ef45ee9bed6badf0663c5cb90e8d1adec1321d"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-
-graceful-fs@^4.1.15:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
@@ -1764,17 +1639,14 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-ini@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-
-ini@~1.3.0:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+ini@^1.3.5, ini@~1.3.0:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 inquirer@^6.4.1:
   version "6.5.2"
@@ -1816,10 +1688,6 @@ is-accessor-descriptor@^1.0.0:
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
-
-is-buffer@^1.0.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz#cfc86ccd5dc5a52fa80489111c6920c457e2d98b"
 
 is-buffer@^1.1.5:
   version "1.1.6"
@@ -1923,12 +1791,10 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-plain-object@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-3.0.0.tgz#47bfc5da1b5d50d64110806c199359482e75a928"
-  integrity sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==
-  dependencies:
-    isobject "^4.0.0"
+is-plain-object@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-4.1.1.tgz#1a14d6452cbd50790edc7fdaa0aed5a40a35ebb5"
+  integrity sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==
 
 is-promise@^2.1.0:
   version "2.1.0"
@@ -1980,11 +1846,6 @@ isobject@^2.0.0:
 isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
-
-isobject@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
-  integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -2484,13 +2345,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-kind-of@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
-  dependencies:
-    is-buffer "^1.0.2"
-
-kind-of@^3.0.3, kind-of@^3.2.0:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:
@@ -2549,26 +2404,11 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash.uniq@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
-  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
-
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5:
+lodash@^4.13.1, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.5:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -2585,11 +2425,6 @@ lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
-
-macos-release@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
-  integrity sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==
 
 make-dir@^2.1.0:
   version "2.1.0"
@@ -2639,21 +2474,11 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-mime-db@~1.25.0:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.25.0.tgz#c18dbd7c73a5dbf6f44a024dc0d165a1e7b1c392"
-
 mime-db@~1.37.0:
   version "1.37.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
 
-mime-types@^2.1.12:
-  version "2.1.13"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.13.tgz#e07aaa9c6c6b9a7ca3012c69003ad25a39e92a88"
-  dependencies:
-    mime-db "~1.25.0"
-
-mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.21"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.21.tgz#28995aa1ecb770742fe6ae7e58f9181c744b3f96"
   dependencies:
@@ -2663,7 +2488,7 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
-minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -2917,11 +2742,6 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-octokit-pagination-methods@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
-  integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
-
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -2955,14 +2775,6 @@ optionator@^0.8.1, optionator@^0.8.2:
 os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-
-os-name@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/os-name/-/os-name-3.1.0.tgz#dec19d966296e1cd62d701a5a66ee1ddeae70801"
-  integrity sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==
-  dependencies:
-    macos-release "^2.2.0"
-    windows-release "^3.1.0"
 
 os-shim@^0.1.2:
   version "0.1.3"
@@ -3134,10 +2946,6 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
-process-nextick-args@~1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
-
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
@@ -3222,19 +3030,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-"readable-stream@^2.0.0 || ^1.1.13":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
-  dependencies:
-    buffer-shims "^1.0.0"
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.2.2:
+"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.2.2:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -3372,13 +3168,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.5.4, rimraf@^2.6.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
-  dependencies:
-    glob "^7.0.5"
-
-rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -3436,11 +3226,7 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
-
-semver@^5.4.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -3661,10 +3447,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -3818,10 +3600,6 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-trim-right@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
-
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -3867,12 +3645,10 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^2.0.1"
 
-universal-user-agent@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-4.0.0.tgz#27da2ec87e32769619f68a14996465ea1cb9df16"
-  integrity sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==
-  dependencies:
-    os-name "^3.1.0"
+universal-user-agent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
+  integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
 unset-value@^1.0.0:
   version "1.0.0"
@@ -3991,13 +3767,6 @@ wide-align@^1.1.0:
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.0.tgz#40edde802a71fea1f070da3e62dcda2e7add96ad"
   dependencies:
     string-width "^1.0.1"
-
-windows-release@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/windows-release/-/windows-release-3.2.0.tgz#8122dad5afc303d833422380680a79cdfa91785f"
-  integrity sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==
-  dependencies:
-    execa "^1.0.0"
 
 wordwrap@~0.0.2:
   version "0.0.3"


### PR DESCRIPTION
#### Description
This PR replaces the REST API usage with GraphQL. This would improve the speed of the CHANGELOG generation by
allowing us to fetch just the last Release and then fetching the latest PRs until the mergedAt timestamp is equal or below the createdAt timestamp of the last Release. There is however an issue, the GraphQL API currently doesn't allow us to sort the list of PRs by the mergedAt value, only by CREATED_AT or UPDATED_AT, which means, there is no reliable way to fetch the just list of PRs we need.

#### Related issues
https://github.com/octokit/graphql.js/issues/191

After the discussion in the issue above, I opened a support ticket with Github with the following text:

> Would it be possible to extend the graphQL API to allow sorting the list of pull requests by mergedAt?
> This would be very helpful in automating the creation of CHANGELOG files since it would allow us to:
> Use the API to fetch the createdAt timestamp of the last release
> Get the list of PRs sorted by mergedAt and iterate through that list, saving each PR until we find the first PR with mergedAt timestamp before the timestamp of the last release.
> This would save us from having to fetch all the PRs which can be slow on bigger repos.

To which  I got the following reply:

> Hi Nelson,
> Thank you for contacting GitHub Support.
> Thanks for your feedback! We're always working to improve GitHub and we consider every suggestion we receive.
> I have passed this on to the relevant team, although I can not promise an E.T.A, your feedback has definitely been recorded!
> Please let us know if you need any further help.

TLDR: They know we want the MERGED_AT sort but they can't promise any ETA on it.