### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.0](https://github.com/uphold/github-changelog-generator/releases/tag/v2.0.0) (2021-04-15)
+- Simplify version grep in release script [\#89](https://github.com/uphold/github-changelog-generator/pull/89) ([Americas](https://github.com/Americas))
+- Add release script [\#88](https://github.com/uphold/github-changelog-generator/pull/88) ([Americas](https://github.com/Americas))
+- Bump packages [\#86](https://github.com/uphold/github-changelog-generator/pull/86) ([Americas](https://github.com/Americas))
+- Improve Changelog generation performance [\#80](https://github.com/uphold/github-changelog-generator/pull/80) ([goncalvesnelson](https://github.com/goncalvesnelson))
+- Release 1.0.2 [\#74](https://github.com/uphold/github-changelog-generator/pull/74) ([cristianooliveira](https://github.com/cristianooliveira))
+
 ## [1.0.2](https://github.com/uphold/github-changelog-generator/releases/tag/v1.0.2) (2019-11-13)
 - Update octokit/rest@16.34.1 [\#73](https://github.com/uphold/github-changelog-generator/pull/73) ([cristianooliveira](https://github.com/cristianooliveira))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uphold/github-changelog-generator",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Generate changelog files from the project's GitHub PRs",
   "license": "MIT",
   "author": "Ricardo Lopes",


### PR DESCRIPTION
# Changelog

## [2.0.0](https://github.com/uphold/github-changelog-generator/releases/tag/v2.0.0) (2021-04-15)
- Simplify version grep in release script [\#89](https://github.com/uphold/github-changelog-generator/pull/89) ([Americas](https://github.com/Americas))
- Add release script [\#88](https://github.com/uphold/github-changelog-generator/pull/88) ([Americas](https://github.com/Americas))
- Bump packages [\#86](https://github.com/uphold/github-changelog-generator/pull/86) ([Americas](https://github.com/Americas))
- Improve Changelog generation performance [\#80](https://github.com/uphold/github-changelog-generator/pull/80) ([goncalvesnelson](https://github.com/goncalvesnelson))
- Release 1.0.2 [\#74](https://github.com/uphold/github-changelog-generator/pull/74) ([cristianooliveira](https://github.com/cristianooliveira))