### PR TITLE
Fix generator to work on repos without releases

### DIFF
--- a/src/changelog-fetcher.js
+++ b/src/changelog-fetcher.js
@@ -109,12 +109,18 @@ class ChangelogFetcher {
           }
           tagName
         }
+        createdAt
       }
     }`;
     const result = await this.client(query, { owner: this.owner, repo: this.repo });
 
     // Extract release from nested result.
     const release = result.repository.latestRelease;
+
+    // For shiny new repositories without releases, use the repository creation date instead.
+    if (!release) {
+      return { tagCommit: { committedDate: moment.utc(result.repository.createdAt) } };
+    }
 
     // Transform string timestamp into moment.
     release.tagCommit.committedDate = moment.utc(release.tagCommit.committedDate);

--- a/test/changelog-fetcher.test.js
+++ b/test/changelog-fetcher.test.js
@@ -20,6 +20,7 @@ describe('ChangelogFetcher', () => {
       return {
         data: {
           repository: {
+            createdAt: moment('2017-10-22T12').toISOString(),
             latestRelease: {
               tagCommit: {
                 committedDate: moment('2018-10-22T12').toISOString()
@@ -651,6 +652,32 @@ describe('ChangelogFetcher', () => {
           committedDate: moment.utc(moment('2018-10-22T12').toISOString())
         },
         tagName: 'latestRelease'
+      });
+    });
+
+    it('should return a mocked latest release if the repository has no releases', async () => {
+      const fetcher = new ChangelogFetcher({
+        owner: 'biz',
+        repo: 'buz',
+        token: 'qux'
+      });
+
+      nock('https://api.github.com')
+        .post('/graphql')
+        .reply(200, (_, requestBody) => {
+          const mockData = getDataForRequest(requestBody);
+
+          mockData.data.repository.latestRelease = undefined;
+
+          return mockData;
+        });
+
+      const result = await fetcher.getLatestRelease();
+
+      expect(result).toEqual({
+        tagCommit: {
+          committedDate: moment.utc(moment('2017-10-22T12').toISOString())
+        }
       });
     });
   });


### PR DESCRIPTION
The generator fails to run on repos without releases, this PR fixes that.

Closes #100 