### PR TITLE
Support http remotes when detecting repo and owner

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ if (!owner || !repo) {
   try {
     const gitconfig = readFileSync(path.join(dir, '.git/config'), 'utf-8');
     const remoteOrigin = ini.parse(gitconfig)['remote "origin"'];
-    const match = remoteOrigin.url.match(/.+:([^/]+)\/(.+)\.git/);
+    const match = remoteOrigin.url.match(/github\.com[:/]([^/]+)\/(.+?)(?:\.git)?$/);
 
     owner = owner || match[1];
     repo = repo || match[2];


### PR DESCRIPTION
This pull-request adds support for git remotes using https. Inside github actions remote urls are all https:// by default.

```js
const [, repo, owner] = 'https://github.com/uphold/github-changelog-generator'.match(/github\.com[:/]([^/]+)\/(.+?)(?:\.git)?$/);

console.log(repo, '|', owner);
// uphold | github-changelog-generator
```

```js
const [, repo, owner] = 'git@github.com:uphold/github-changelog-generator.git'.match(/github\.com[:/]([^/]+)\/(.+?)(?:\.git)?$/);

console.log(repo, '|', owner);
// uphold | github-changelog-generator
```