### PR TITLE
Add support for mono-repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # github-changelog-generator
-Generate changelog files from the project's GitHub PRs
+
+Generate changelog files from the project's GitHub PRs.
 
 ## Usage
+
 Generate a new [GitHub Personal Access Token](https://github.com/settings/tokens) and save it to your `.zshrc.local`, `.bashrc.local` or similar:
 
 ```sh
@@ -19,14 +21,16 @@ $ github-changelog-generator --help
 
   Options:
 
-    -h, --help                       output usage information
-    -b, --base-branch <name>         [optional] specify the base branch name - master by default
-    -f, --future-release <version>   [optional] specify the next release version
-    -t, --future-release-tag <name>  [optional] specify the next release tag name if it is different from the release version
-    -l, --labels <names>             [optional] labels to filter pull requests by
-    -o, --owner <name>               [optional] owner of the repository
-    -r, --repo <name>                [optional] name of the repository
-    --rebuild                        rebuild the full changelog
+    -h,   --help                       output usage information
+    -b,   --base-branch <name>         [optional] specify the base branch name - master by default
+    -f,   --future-release <version>   [optional] specify the next release version
+    -t,   --future-release-tag <name>  [optional] specify the next release tag name if it is different from the release version
+    -rtp, --release-tag-prefix         [optional] release tag prefix to consider when finding the latest release, useful for monorepos
+    -cfp, --changed-files-prefix       [optional] changed files prefix to consider when finding pull-requests, useful for monorepos
+    -l,   --labels <names>             [optional] labels to filter pull requests by
+    -o,   --owner <name>               [optional] owner of the repository
+    -r,   --repo <name>                [optional] name of the repository
+    --rebuild                          rebuild the full changelog
 ```
 
 To generate a changelog for your GitHub project, use the following command:
@@ -43,12 +47,20 @@ Example:
 $ echo "$(github-changelog-generator --base-branch=production)\n$(tail -n +2 CHANGELOG.md)" > CHANGELOG.md
 ```
 
-The `--future-release` and `--future-release-tag` options are optional. If you just want to build a new changelog without a new release, you can skip those options, and `github-changelog-generator` will create a changelog for existing releases only. Also, if your future release tag name is the same as your future release version number, then you can skip `--future-release-tag`.
+The `--future-release` and `--future-release-tag` options are optional. If your future release tag name is the same as your future release version number, then you can skip `--future-release-tag`.
 
 Example:
 
 ```sh
 $ echo "$(github-changelog-generator --future-release=1.2.3 --future-release-tag=v1.2.3)\n$(tail -n +2 CHANGELOG.md)" > CHANGELOG.md
+```
+
+If you are on a mono-repository, you will need to use `--release-tag-prefix` in order to filter release tags of the package you are targeting. There's also the `--changed-files-prefix` option that may be used to specify the base directory of the package. However, this should be automatic in most cases, except when we are unable to infer the root folder.
+
+Example:
+
+```sh
+$ echo "$(github-changelog-generator --future-release=my-package@1.2.3 --future-release-tag=my-package@v1.2.3 --release-tag-prefix=my-package@v)\n$(tail -n +2 CHANGELOG.md)" > CHANGELOG.md
 ```
 
 The `--owner` and `--repo` options allow you to specify the owner and name of the GitHub repository, respectively. If omitted, they will default to the values found in the project's git config.
@@ -67,7 +79,7 @@ Example:
 $ echo "$(github-changelog-generator --labels projectX,general)\n$(tail -n +2 CHANGELOG.md)" > CHANGELOG.md
 ```
 
-The `--rebuild` option allows you to fetch the repository's full changelog history. 
+The `--rebuild` option allows you to fetch the repository's full changelog history.
 Starting on major version 2, the default behavior for the generator is to only create the changelog for the pull requests that come after the latest release,
 so this option allows for backwards compatibility.
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@octokit/graphql": "^4.8.0",
     "commander": "^8.3.0",
     "ini": "^2.0.0",
+    "look-it-up": "^2.1.0",
     "moment": "^2.29.1"
   },
   "devDependencies": {

--- a/test/changelog-formatter.test.js
+++ b/test/changelog-formatter.test.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-const { formatChangelog } = require('src/changelog-formatter');
+const { formatChangelog } = require('../src/changelog-formatter');
 const moment = require('moment');
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2216,6 +2216,11 @@ lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+look-it-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/look-it-up/-/look-it-up-2.1.0.tgz#278a7ffc9da60a928452a0bab5452bb8855d7d13"
+  integrity sha512-nMoGWW2HurtuJf6XAL56FWTDCWLOTSsanrgwOyaR5Y4e3zfG5N/0cU5xWZSEU3tBxhQugRbV1xL9jb+ug7yZww==
+
 lru-cache@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"


### PR DESCRIPTION
The current implementation does not work with mono-repos:

1. It assumes `.git` is in the cwd
2. It doesn't allow filtering releases. In a mono-repo, there are different releases and tags per package (usually prefixed by the package name, like `my-package@v1.0.0`
3. It doesn't allow filtering pull-requests by changes files, so that only pull-requests that affected a package are considered.

I've fixed 1 and implemented options for 2 and 3.

Example usage:

```sh
github-changelog-generator --future-release my-service@v0.1.0 --release-tag-prefix my-service@v
```