### PR TITLE
Revert release title formatting to prefer `name` over `tagName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 - Switch release-it config to CommonJS [\#131](https://github.com/uphold/github-changelog-generator/pull/131) ([Americas](https://github.com/Americas))
 
-## [4.0.1](https://github.com/uphold/github-changelog-generator/releases/tag/4.0.1) (2025-03-20)
+## [v4.0.1](https://github.com/uphold/github-changelog-generator/releases/tag/4.0.1) (2025-03-20)
 
 - Update release process configuration [\#130](https://github.com/uphold/github-changelog-generator/pull/130) ([risantos](https://github.com/risantos))
 - Update release-it file type and CHANGELOG [\#129](https://github.com/uphold/github-changelog-generator/pull/129) ([risantos](https://github.com/risantos))
 
-## [4.0.0](https://github.com/uphold/github-changelog-generator/releases/tag/4.0.0) (2025-03-20)
+## [v4.0.0](https://github.com/uphold/github-changelog-generator/releases/tag/4.0.0) (2025-03-20)
 
 - Remove debug from release workflow [\#128](https://github.com/uphold/github-changelog-generator/pull/128) ([Americas](https://github.com/Americas))
 - Debug release workflow [\#127](https://github.com/uphold/github-changelog-generator/pull/127) ([Americas](https://github.com/Americas))

--- a/src/changelog-formatter.js
+++ b/src/changelog-formatter.js
@@ -8,9 +8,9 @@ export const formatChangelog = releases => {
   const changelog = ['# Changelog\n'];
 
   for (const release of releases) {
-    const releaseNumber = release.tagName || release.name;
+    const releaseTitle = release.name || release.tagName;
 
-    changelog.push(`\n## [${releaseNumber}](${release.url}) (${release.createdAt.format('YYYY-MM-DD')})\n\n`);
+    changelog.push(`\n## [${releaseTitle}](${release.url}) (${release.createdAt.format('YYYY-MM-DD')})\n\n`);
 
     for (const { author, number, title, url } of release.pullRequests) {
       changelog.push(`- ${title} [\\#${number}](${url}) ([${author.login}](${author.url}))\n`);

--- a/test/changelog-formatter.test.js
+++ b/test/changelog-formatter.test.js
@@ -88,7 +88,7 @@ describe('ChangelogFormatter', () => {
 
       expect(formatChangelog(releases)).toEqual([
         '# Changelog\n',
-        '\n## [foo-tag](foo-url) (2018-10-23)\n\n',
+        '\n## [foo-name](foo-url) (2018-10-23)\n\n',
         '- foobar-title [\\#foobar-number](foobar-url) ([foobar-user-login](foobar-user-url))\n',
         '- foobiz-title [\\#foobiz-number](foobiz-url) ([foobiz-user-login](foobiz-user-url))\n',
         '\n## [bar-tag](bar-url) (2018-10-22)\n\n',


### PR DESCRIPTION
## Description

- Revert to prefer `release.name` over `release.tagName` for formatting release titles to maintain consistency.